### PR TITLE
Add generic type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- The macros, matrix, filter and measurement structs are now generic on the data type.
+  If no type is provided, it defaults to `f32`.
+
 ## [0.2.3] - 2024-06-03
 
 [0.2.3]: https://github.com/sunsided/minikalman-rs/releases/tag/v0.2.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,9 @@ stdint = ["dep:stdint", "stdint/std"]
 unsafe = []
 
 [dependencies]
+fixed = { version = "1.27.0", optional = true }
 micromath = { version = "2.1.0", optional = true }
+num-traits = "0.2.19"
 stdint = { version = "1.0.0", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/benches/gravity.rs
+++ b/benches/gravity.rs
@@ -5,15 +5,15 @@ use minikalman::{
     create_buffer_Q, create_buffer_R, create_buffer_S, create_buffer_temp_BQ,
     create_buffer_temp_HP, create_buffer_temp_KHP, create_buffer_temp_P, create_buffer_temp_PHt,
     create_buffer_temp_S_inv, create_buffer_temp_x, create_buffer_u, create_buffer_x,
-    create_buffer_y, create_buffer_z, matrix_data_t, Kalman, Measurement,
+    create_buffer_y, create_buffer_z, Kalman, Measurement,
 };
 
-const REAL_DISTANCE: [matrix_data_t; 15] = [
+const REAL_DISTANCE: [f32; 15] = [
     0.0, 4.905, 19.62, 44.145, 78.48, 122.63, 176.58, 240.35, 313.92, 397.31, 490.5, 593.51,
     706.32, 828.94, 961.38,
 ];
 
-const MEASUREMENT_ERROR: [matrix_data_t; 15] = [
+const MEASUREMENT_ERROR: [f32; 15] = [
     0.13442, 0.45847, -0.56471, 0.21554, 0.079691, -0.32692, -0.1084, 0.085656, 0.8946, 0.69236,
     -0.33747, 0.75873, 0.18135, -0.015764, 0.17869,
 ];
@@ -198,7 +198,7 @@ fn initialize_state_vector(filter: &mut Kalman<NUM_STATES, NUM_INPUTS>) {
 fn initialize_state_transition_matrix(filter: &mut Kalman<NUM_STATES, NUM_INPUTS>) {
     filter.state_transition_apply(|a| {
         // Time constant.
-        const T: matrix_data_t = 1 as _;
+        const T: f32 = 1 as _;
 
         // Transition of x to s.
         a.set(0, 0, 1 as _); // 1

--- a/examples/gravity.rs
+++ b/examples/gravity.rs
@@ -14,7 +14,7 @@ use minikalman::{
     create_buffer_Q, create_buffer_R, create_buffer_S, create_buffer_temp_BQ,
     create_buffer_temp_HP, create_buffer_temp_KHP, create_buffer_temp_P, create_buffer_temp_PHt,
     create_buffer_temp_S_inv, create_buffer_temp_x, create_buffer_u, create_buffer_x,
-    create_buffer_y, create_buffer_z, matrix_data_t, Kalman, Measurement,
+    create_buffer_y, create_buffer_z, Kalman, Measurement,
 };
 
 /// Measurements.
@@ -24,7 +24,7 @@ use minikalman::{
 /// s = s + v*T + g*0.5*T^2;
 /// v = v + g*T;
 /// ```
-const REAL_DISTANCE: [matrix_data_t; 15] = [
+const REAL_DISTANCE: [f32; 15] = [
     0.0, 4.905, 19.62, 44.145, 78.48, 122.63, 176.58, 240.35, 313.92, 397.31, 490.5, 593.51,
     706.32, 828.94, 961.38,
 ];
@@ -35,7 +35,7 @@ const REAL_DISTANCE: [matrix_data_t; 15] = [
 /// ```matlab
 /// noise = 0.5^2*randn(15,1);
 /// ```
-const MEASUREMENT_ERROR: [matrix_data_t; 15] = [
+const MEASUREMENT_ERROR: [f32; 15] = [
     0.13442, 0.45847, -0.56471, 0.21554, 0.079691, -0.32692, -0.1084, 0.085656, 0.8946, 0.69236,
     -0.33747, 0.75873, 0.18135, -0.015764, 0.17869,
 ];
@@ -75,7 +75,7 @@ fn main() {
     let mut gravity_temp_PHt = create_buffer_temp_PHt!(NUM_STATES, NUM_MEASUREMENTS);
     let mut gravity_temp_KHP = create_buffer_temp_KHP!(NUM_STATES);
 
-    let mut filter = Kalman::<NUM_STATES, NUM_INPUTS>::new_from_buffers(
+    let mut filter = Kalman::<NUM_STATES, NUM_INPUTS>::new_direct(
         &mut gravity_A,
         &mut gravity_x,
         &mut gravity_B,
@@ -148,7 +148,7 @@ fn initialize_state_vector(filter: &mut Kalman<'_, NUM_STATES, NUM_INPUTS>) {
 fn initialize_state_transition_matrix(filter: &mut Kalman<'_, NUM_STATES, NUM_INPUTS>) {
     filter.state_transition_apply(|a| {
         // Time constant.
-        const T: matrix_data_t = 1 as _;
+        const T: f32 = 1 as _;
 
         // Transition of x to s.
         a.set(0, 0, 1 as _); // 1
@@ -217,9 +217,9 @@ fn initialize_position_measurement_process_noise_matrix(
 
 /// Print the state prediction. Will do nothing on `no_std` features.
 #[allow(unused)]
-fn print_state_prediction<T>(t: usize, x: T)
+fn print_state_prediction<T, D>(t: usize, x: T)
 where
-    T: AsRef<[matrix_data_t]>,
+    T: AsRef<[D]>,
 {
     let x = x.as_ref();
     #[cfg(not(feature = "no_std"))]
@@ -234,9 +234,9 @@ where
 
 /// Print the measurement corrected state. Will do nothing on `no_std` features.
 #[allow(unused)]
-fn print_state_correction<T>(t: usize, x: T)
+fn print_state_correction<T, D>(t: usize, x: T)
 where
-    T: AsRef<[matrix_data_t]>,
+    T: AsRef<[D]>,
 {
     let x = x.as_ref();
     #[cfg(not(feature = "no_std"))]

--- a/examples/gravity.rs
+++ b/examples/gravity.rs
@@ -217,9 +217,9 @@ fn initialize_position_measurement_process_noise_matrix(
 
 /// Print the state prediction. Will do nothing on `no_std` features.
 #[allow(unused)]
-fn print_state_prediction<T, D>(t: usize, x: T)
+fn print_state_prediction<T>(t: usize, x: T)
 where
-    T: AsRef<[D]>,
+    T: AsRef<[f32]>,
 {
     let x = x.as_ref();
     #[cfg(not(feature = "no_std"))]
@@ -234,9 +234,9 @@ where
 
 /// Print the measurement corrected state. Will do nothing on `no_std` features.
 #[allow(unused)]
-fn print_state_correction<T, D>(t: usize, x: T)
+fn print_state_correction<T>(t: usize, x: T)
 where
-    T: AsRef<[D]>,
+    T: AsRef<[f32]>,
 {
     let x = x.as_ref();
     #[cfg(not(feature = "no_std"))]

--- a/src/kalman.rs
+++ b/src/kalman.rs
@@ -88,7 +88,7 @@ impl<'a, const STATES: usize, const INPUTS: usize, T> Kalman<'a, STATES, INPUTS,
     /// let mut gravity_temp_P = create_buffer_temp_P!(NUM_STATES);
     /// let mut gravity_temp_BQ = create_buffer_temp_BQ!(NUM_STATES, NUM_INPUTS);
     ///
-    /// let mut filter = Kalman::<NUM_STATES, NUM_INPUTS>::new_from_buffers(
+    /// let mut filter = Kalman::<NUM_STATES, NUM_INPUTS>::new_direct(
     ///     &mut gravity_A,
     ///     &mut gravity_x,
     ///     &mut gravity_B,
@@ -493,7 +493,7 @@ impl<'a, const STATES: usize, const INPUTS: usize, T> Kalman<'a, STATES, INPUTS,
     /// # let mut gravity_temp_P = create_buffer_temp_P!(NUM_STATES);
     /// # let mut gravity_temp_BQ = create_buffer_temp_BQ!(NUM_STATES, NUM_INPUTS);
     /// #
-    /// # let mut filter = Kalman::<NUM_STATES, NUM_INPUTS>::new_from_buffers(
+    /// # let mut filter = Kalman::<NUM_STATES, NUM_INPUTS>::new_direct(
     /// #     &mut gravity_A,
     /// #     &mut gravity_x,
     /// #     &mut gravity_B,
@@ -590,7 +590,7 @@ impl<'a, const STATES: usize, const INPUTS: usize, T> Kalman<'a, STATES, INPUTS,
     /// # let mut gravity_temp_P = create_buffer_temp_P!(NUM_STATES);
     /// # let mut gravity_temp_BQ = create_buffer_temp_BQ!(NUM_STATES, NUM_INPUTS);
     /// #
-    /// # let mut filter = Kalman::<NUM_STATES, NUM_INPUTS>::new_from_buffers(
+    /// # let mut filter = Kalman::<NUM_STATES, NUM_INPUTS>::new_direct(
     /// #     &mut gravity_A,
     /// #     &mut gravity_x,
     /// #     &mut gravity_B,
@@ -776,7 +776,7 @@ impl<'a, const STATES: usize, const INPUTS: usize, T> Kalman<'a, STATES, INPUTS,
     /// # let mut gravity_temp_P = create_buffer_temp_P!(NUM_STATES);
     /// # let mut gravity_temp_BQ = create_buffer_temp_BQ!(NUM_STATES, NUM_INPUTS);
     /// #
-    /// # let mut filter = Kalman::<NUM_STATES, NUM_INPUTS>::new_from_buffers(
+    /// # let mut filter = Kalman::<NUM_STATES, NUM_INPUTS>::new_direct(
     /// #     &mut gravity_A,
     /// #     &mut gravity_x,
     /// #     &mut gravity_B,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ mod matrix_ops;
 mod measurement;
 mod types;
 
-pub use matrix::matrix_data_t;
 pub use matrix::Matrix;
 
 pub use crate::kalman::Kalman;
@@ -50,13 +49,15 @@ pub use crate::types::*;
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_A {
-    ( $num_states:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_states:expr ) => {
+        (create_buffer_A!($num_states, f32))
+    };
+    ( $num_states:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_STATES_: FastUInt16 = ($num_states) as FastUInt16;
         const COUNT: usize = (NUM_STATES_ * NUM_STATES_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -78,13 +79,15 @@ macro_rules! create_buffer_A {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_P {
-    ( $num_states:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_states:expr ) => {
+        (create_buffer_P!($num_states, f32))
+    };
+    ( $num_states:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_STATES_: FastUInt16 = ($num_states) as FastUInt16;
         const COUNT: usize = (NUM_STATES_ * NUM_STATES_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -106,13 +109,15 @@ macro_rules! create_buffer_P {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_x {
-    ( $num_states:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_states:expr ) => {
+        (create_buffer_x![$num_states, f32])
+    };
+    ( $num_states:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_STATES_: FastUInt16 = ($num_states) as FastUInt16;
         const COUNT: usize = (NUM_STATES_ * 1) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -135,13 +140,15 @@ macro_rules! create_buffer_x {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_u {
-    ( $num_inputs:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_inputs:expr ) => {
+        (create_buffer_u![$num_inputs, f32])
+    };
+    ( $num_inputs:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_INPUTS_: FastUInt16 = ($num_inputs) as FastUInt16;
         const COUNT: usize = (NUM_INPUTS_ * 1) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -165,14 +172,16 @@ macro_rules! create_buffer_u {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_B {
-    ( $num_states:expr, $num_inputs:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_states:expr, $num_inputs:expr ) => {
+        (create_buffer_B![$num_states, $num_inputs, f32])
+    };
+    ( $num_states:expr, $num_inputs:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_STATES_: FastUInt16 = ($num_states) as FastUInt16;
         const NUM_INPUTS_: FastUInt16 = ($num_inputs) as FastUInt16;
         const COUNT: usize = (NUM_STATES_ * NUM_INPUTS_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -195,13 +204,15 @@ macro_rules! create_buffer_B {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_Q {
-    ( $num_inputs:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_states:expr ) => {
+        (create_buffer_Q![$num_states, f32])
+    };
+    ( $num_inputs:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_INPUTS_: FastUInt16 = ($num_inputs) as FastUInt16;
         const COUNT: usize = (NUM_INPUTS_ * NUM_INPUTS_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -227,13 +238,15 @@ macro_rules! create_buffer_Q {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_z {
-    ( $num_measurements:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_states:expr ) => {
+        (create_buffer_z![$num_states, f32])
+    };
+    ( $num_measurements:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_MEASUREMENTS_: FastUInt16 = ($num_measurements) as FastUInt16;
         const COUNT: usize = (NUM_MEASUREMENTS_ * 1) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -260,14 +273,16 @@ macro_rules! create_buffer_z {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_H {
-    ( $num_measurements:expr, $num_states:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_measurements:expr, $num_states:expr ) => {
+        (create_buffer_H![$num_measurements, $num_states, f32])
+    };
+    ( $num_measurements:expr, $num_states:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_MEASUREMENTS_: FastUInt16 = ($num_measurements) as FastUInt16;
         const NUM_STATES_: FastUInt16 = ($num_states) as FastUInt16;
         const COUNT: usize = (NUM_MEASUREMENTS_ * NUM_STATES_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -293,13 +308,15 @@ macro_rules! create_buffer_H {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_R {
-    ( $num_measurements:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_measurements:expr ) => {
+        (create_buffer_R![$num_measurements, f32])
+    };
+    ( $num_measurements:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_MEASUREMENTS_: FastUInt16 = ($num_measurements) as FastUInt16;
         const COUNT: usize = (NUM_MEASUREMENTS_ * NUM_MEASUREMENTS_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -325,13 +342,15 @@ macro_rules! create_buffer_R {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_y {
-    ( $num_measurements:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_measurements:expr ) => {
+        (create_buffer_y![$num_measurements, f32])
+    };
+    ( $num_measurements:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_MEASUREMENTS_: FastUInt16 = ($num_measurements) as FastUInt16;
         const COUNT: usize = (NUM_MEASUREMENTS_ * 1) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -357,13 +376,15 @@ macro_rules! create_buffer_y {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_S {
-    ( $num_measurements:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_measurements:expr ) => {
+        (create_buffer_S![$num_measurements, f32])
+    };
+    ( $num_measurements:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_MEASUREMENTS_: FastUInt16 = ($num_measurements) as FastUInt16;
         const COUNT: usize = (NUM_MEASUREMENTS_ * NUM_MEASUREMENTS_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -390,14 +411,16 @@ macro_rules! create_buffer_S {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_K {
-    ( $num_states:expr, $num_measurements:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_states:expr, $num_measurements:expr ) => {
+        (create_buffer_K![$num_states, $num_measurements, f32])
+    };
+    ( $num_states:expr, $num_measurements:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_STATES_: FastUInt16 = ($num_states) as FastUInt16;
         const NUM_MEASUREMENTS_: FastUInt16 = ($num_measurements) as FastUInt16;
         const COUNT: usize = (NUM_STATES_ * NUM_MEASUREMENTS_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -420,13 +443,15 @@ macro_rules! create_buffer_K {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_temp_x {
-    ( $num_states:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_states:expr ) => {
+        (create_buffer_temp_x![$num_states, f32])
+    };
+    ( $num_states:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_STATES_: FastUInt16 = ($num_states) as FastUInt16;
         const COUNT: usize = (NUM_STATES_ * 1) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -449,13 +474,15 @@ macro_rules! create_buffer_temp_x {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_temp_P {
-    ( $num_states:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_states:expr ) => {
+        (create_buffer_temp_P![$num_states, f32])
+    };
+    ( $num_states:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_STATES_: FastUInt16 = ($num_states) as FastUInt16;
         const COUNT: usize = (NUM_STATES_ * NUM_STATES_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -479,14 +506,16 @@ macro_rules! create_buffer_temp_P {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_temp_BQ {
-    ( $num_states:expr, $num_inputs:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_states:expr, $num_inputs:expr ) => {
+        (create_buffer_temp_BQ![$num_states, $num_inputs, f32])
+    };
+    ( $num_states:expr, $num_inputs:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_STATES_: FastUInt16 = ($num_states) as FastUInt16;
         const NUM_INPUTS_: FastUInt16 = ($num_inputs) as FastUInt16;
         const COUNT: usize = (NUM_STATES_ * NUM_INPUTS_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -510,13 +539,15 @@ macro_rules! create_buffer_temp_BQ {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_temp_S_inv {
-    ( $num_measurements:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_measurements:expr ) => {
+        (create_buffer_temp_S_inv![$num_measurements, f32])
+    };
+    ( $num_measurements:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_MEASUREMENTS_: FastUInt16 = ($num_measurements) as FastUInt16;
         const COUNT: usize = (NUM_MEASUREMENTS_ * NUM_MEASUREMENTS_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -541,14 +572,16 @@ macro_rules! create_buffer_temp_S_inv {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_temp_HP {
-    ( $num_measurements:expr, $num_states:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_measurements:expr, $num_states:expr ) => {
+        (create_buffer_temp_HP![$num_measurements, $num_states, f32])
+    };
+    ( $num_measurements:expr, $num_states:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_MEASUREMENTS_: FastUInt16 = ($num_measurements) as FastUInt16;
         const NUM_STATES_: FastUInt16 = ($num_states) as FastUInt16;
         const COUNT: usize = (NUM_STATES_ * NUM_MEASUREMENTS_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -573,14 +606,16 @@ macro_rules! create_buffer_temp_HP {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_temp_PHt {
-    ( $num_states:expr, $num_measurements:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_states:expr, $num_measurements:expr ) => {
+        (create_buffer_temp_PHt![$num_states, $num_measurements, f32])
+    };
+    ( $num_states:expr, $num_measurements:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_STATES_: FastUInt16 = ($num_states) as FastUInt16;
         const NUM_MEASUREMENTS_: FastUInt16 = ($num_measurements) as FastUInt16;
         const COUNT: usize = (NUM_STATES_ * NUM_MEASUREMENTS_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }
 
@@ -605,12 +640,14 @@ macro_rules! create_buffer_temp_PHt {
 #[macro_export]
 #[allow(non_snake_case)]
 macro_rules! create_buffer_temp_KHP {
-    ( $num_states:expr ) => {{
-        use $crate::matrix_data_t;
+    ( $num_states:expr ) => {
+        (create_buffer_temp_KHP![$num_states, f32])
+    };
+    ( $num_states:expr, $t:ty ) => {{
         use $crate::FastUInt16;
 
         const NUM_STATES_: FastUInt16 = ($num_states) as FastUInt16;
         const COUNT: usize = (NUM_STATES_ * NUM_STATES_) as usize;
-        [0.0 as matrix_data_t; COUNT]
+        [0.0 as $t; COUNT]
     }};
 }

--- a/src/matrix_ops.rs
+++ b/src/matrix_ops.rs
@@ -1,8 +1,7 @@
-use crate::matrix_data_t;
 use crate::types::{FastUInt16, FastUInt8};
 
 /// Matrix operations relevant to the Kalman filter calculation.
-pub trait MatrixBase {
+pub trait MatrixBase<T> {
     /// Gets the number of rows.
     fn rows(&self) -> FastUInt8;
 
@@ -19,14 +18,14 @@ pub trait MatrixBase {
     }
 
     /// Gets an immutable reference to the data.
-    fn data_ref(&self) -> &[matrix_data_t];
+    fn data_ref(&self) -> &[T];
 
     /// Gets a mutable reference to the data.
-    fn data_mut(&mut self) -> &mut [matrix_data_t];
+    fn data_mut(&mut self) -> &mut [T];
 }
 
 /// Matrix operations relevant to the Kalman filter calculation.
-pub trait MatrixOps: MatrixBase {
+pub trait MatrixOps<T>: MatrixBase<T> {
     type Target;
 
     /// Inverts a square lower triangular matrix. Meant to be used with
@@ -53,7 +52,7 @@ pub trait MatrixOps: MatrixBase {
     /// * `b` - Matrix B
     /// * `c` - Resulting matrix C (will be overwritten)
     /// * `aux` -  Auxiliary vector that can hold a column of `b`.
-    fn mult_buffered(&self, b: &Self::Target, c: &mut Self::Target, baux: &mut [matrix_data_t]);
+    fn mult_buffered(&self, b: &Self::Target, c: &mut Self::Target, baux: &mut [T]);
 
     /// Performs a matrix multiplication such that `C = A * B`.
     ///
@@ -105,7 +104,7 @@ pub trait MatrixOps: MatrixBase {
     /// * `b` - Matrix B
     /// * `scale` - Scaling factor
     /// * `c` - Resulting matrix C(will be overwritten)
-    fn multscale_transb(&self, b: &Self::Target, scale: matrix_data_t, c: &mut Self::Target);
+    fn multscale_transb(&self, b: &Self::Target, scale: T, c: &mut Self::Target);
 
     /// Gets a matrix element
     ///
@@ -116,7 +115,7 @@ pub trait MatrixOps: MatrixBase {
     ///
     /// ## Returns
     /// The value at the given cell.
-    fn get(&self, row: FastUInt8, column: FastUInt8) -> matrix_data_t;
+    fn get(&self, row: FastUInt8, column: FastUInt8) -> T;
 
     /// Sets a matrix element
     ///
@@ -124,7 +123,7 @@ pub trait MatrixOps: MatrixBase {
     /// * `mat` - The matrix to set    /// * `rows` - The row
     /// * `cols` - The column
     /// * `value` - The value to set
-    fn set(&mut self, row: FastUInt8, column: FastUInt8, value: matrix_data_t);
+    fn set(&mut self, row: FastUInt8, column: FastUInt8, value: T);
 
     /// Sets matrix elements in a symmetric matrix
     ///
@@ -133,7 +132,7 @@ pub trait MatrixOps: MatrixBase {
     /// * `rows` - The row
     /// * `cols` - The column
     /// * `value` - The value to set
-    fn set_symmetric(&mut self, row: FastUInt8, column: FastUInt8, value: matrix_data_t);
+    fn set_symmetric(&mut self, row: FastUInt8, column: FastUInt8, value: T);
 
     /// Gets a copy of a matrix column
     ///
@@ -141,7 +140,7 @@ pub trait MatrixOps: MatrixBase {
     /// * `self` - The matrix to initialize
     /// * `column` - The column
     /// * `col_data` - Pointer to an array of the correct length to hold a column of matrix `mat`.
-    fn get_column_copy(&self, column: FastUInt8, col_data: &mut [matrix_data_t]);
+    fn get_column_copy(&self, column: FastUInt8, col_data: &mut [T]);
 
     /// Gets a copy of a matrix row
     ///
@@ -149,7 +148,7 @@ pub trait MatrixOps: MatrixBase {
     /// * `self` - The matrix to initialize
     /// * `rows` - The row
     /// * `row_data` - Pointer to an array of the correct length to hold a row of matrix `mat`.
-    fn get_row_copy(&self, row: FastUInt8, row_data: &mut [matrix_data_t]);
+    fn get_row_copy(&self, row: FastUInt8, row_data: &mut [T]);
 
     /// Copies the matrix from `mat` to `target`.
     ///

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -355,7 +355,7 @@ impl<'a, const STATES: usize, const MEASUREMENTS: usize, T>
     /// # let mut gravity_temp_P = create_buffer_temp_P!(NUM_STATES);
     /// # let mut gravity_temp_BQ = create_buffer_temp_BQ!(NUM_STATES, NUM_INPUTS);
     /// #
-    /// # let mut filter = Kalman::<NUM_STATES, NUM_INPUTS>::new_from_buffers(
+    /// # let mut filter = Kalman::<NUM_STATES, NUM_INPUTS>::new_direct(
     /// #     &mut gravity_A,
     /// #     &mut gravity_x,
     /// #     &mut gravity_B,

--- a/tests/gravity.rs
+++ b/tests/gravity.rs
@@ -12,7 +12,7 @@ use minikalman::{
     create_buffer_Q, create_buffer_R, create_buffer_S, create_buffer_temp_BQ,
     create_buffer_temp_HP, create_buffer_temp_KHP, create_buffer_temp_P, create_buffer_temp_PHt,
     create_buffer_temp_S_inv, create_buffer_temp_x, create_buffer_u, create_buffer_x,
-    create_buffer_y, create_buffer_z, matrix_data_t, Kalman, Measurement,
+    create_buffer_y, create_buffer_z, Kalman, Measurement,
 };
 
 /// Measurements.
@@ -22,7 +22,7 @@ use minikalman::{
 /// s = s + v*T + g*0.5*T^2;
 /// v = v + g*T;
 /// ```
-const REAL_DISTANCE: [matrix_data_t; 15] = [
+const REAL_DISTANCE: [f32; 15] = [
     0.0, 4.905, 19.62, 44.145, 78.48, 122.63, 176.58, 240.35, 313.92, 397.31, 490.5, 593.51,
     706.32, 828.94, 961.38,
 ];
@@ -33,7 +33,7 @@ const REAL_DISTANCE: [matrix_data_t; 15] = [
 /// ```matlab
 /// noise = 0.5^2*randn(15,1);
 /// ```
-const MEASUREMENT_ERROR: [matrix_data_t; 15] = [
+const MEASUREMENT_ERROR: [f32; 15] = [
     0.13442, 0.45847, -0.56471, 0.21554, 0.079691, -0.32692, -0.1084, 0.085656, 0.8946, 0.69236,
     -0.33747, 0.75873, 0.18135, -0.015764, 0.17869,
 ];
@@ -144,7 +144,7 @@ fn initialize_state_vector(filter: &mut Kalman<'_, NUM_STATES, NUM_INPUTS>) {
 fn initialize_state_transition_matrix(filter: &mut Kalman<'_, NUM_STATES, NUM_INPUTS>) {
     filter.state_transition_apply(|a| {
         // Time constant.
-        const T: matrix_data_t = 1 as _;
+        const T: f32 = 1 as _;
 
         // Transition of x to s.
         a.set(0, 0, 1 as _); // 1


### PR DESCRIPTION
This makes the filter and matrix types generic on `T`, which defaults to `f32`. This should be the first step in supporting arbitrary precision and fixed-point calculation.