### PR TITLE
Add Kalman Filter, Input and Measurement builders

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,16 +7,18 @@ on:
     paths:
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - 'build.rs'
-      - 'src/**'
+      - 'crates/**/minikalman/**'
+      - 'crates/**/minikalman-traits/**'
+      - 'xbuild-tests/**'
       - '.github/workflows/rust.yml'
   pull_request:
     branches: [ "main" ]
     paths:
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - 'build.rs'
-      - 'src/**'
+      - 'crates/**/minikalman/**'
+      - 'crates/**/minikalman-traits/**'
+      - 'xbuild-tests/**'
       - '.github/workflows/rust.yml'
 
 env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,10 +24,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-defaults:
-  run:
-    working-directory: crates/minikalman
-
 jobs:
   lint:
     name: Lint
@@ -57,7 +53,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Generate code coverage
-        run: cargo llvm-cov nextest --features=std,float,fixed,alloc --package minikalman --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --features=std,fixed --package minikalman --package minikalman-traits --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -72,14 +68,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@nextest
-      - name: Run Example
-        run: cargo run --example=gravity --no-default-features --features=float,std
-      - name: Run tests
-        run: cargo nextest run --verbose --no-default-features --features=float
-      - name: Run tests
-        run: cargo nextest run --verbose --features=stdint,float
+      - name: Run Example (float)
+        run: cargo run --example=gravity --no-default-features --features=std
+      - name: Run tests (std)
+        run: cargo nextest run --verbose --package minikalman --package minikalman-traits --no-default-features --features=std
+      - name: Run tests (libm)
+        run: cargo nextest run --verbose --package minikalman --package minikalman-traits --no-default-features --features=libm
       - name: Run doctests
-        run: cargo test --doc --verbose --no-default-features --features=std,float
+        run: cargo test --doc --verbose --package minikalman --package minikalman-traits --no-default-features --features=std
+      - name: Run doctests (libm)
+        run: cargo test --doc --verbose --package minikalman --package minikalman-traits --no-default-features --features=std
 
   build-fixed:
     needs: lint
@@ -88,12 +86,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@nextest
-      - name: Run Example
+      - name: Run Example (fixed)
         run: cargo run --example=fixed --no-default-features --features=fixed,std
-      - name: Run tests
-        run: cargo nextest run --verbose --no-default-features --features=float,fixed
-      - name: Run doctests
-        run: cargo test --doc --verbose --no-default-features --features=float,fixed
+      - name: Run tests (fixed)
+        run: cargo nextest run --verbose --package minikalman --package minikalman-traits --no-default-features --features=fixed,std
+      - name: Run doctests (fixed)
+        run: cargo test --doc --verbose --package minikalman --package minikalman-traits --no-default-features --features=fixed,std
 
   build-others:
     needs:
@@ -109,6 +107,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@nextest
       - name: Run tests
-        run: cargo nextest run --verbose
+        run: cargo nextest run --package minikalman --package minikalman-traits --verbose
       - name: Run doctests
-        run: cargo test --doc --verbose
+        run: cargo test --doc --package minikalman --package minikalman-traits --verbose

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ cargo build --features=alloc
 
 ### Targets with allocations (`std` or `alloc`)
 
+When the `alloc` crate feature is enabled either directly or implicitly via `std`,
+some builders are enabled that allow for simple creation of filters. This should help non-embedded use cases, or any
+use case that does not have to explicitly manage buffer locations, to get an easier start:
+
 ```rust
 const NUM_STATES: usize = 3;
 const NUM_INPUTS: usize = 2;

--- a/README.md
+++ b/README.md
@@ -99,41 +99,13 @@ the [libfixkalman](https://github.com/sunsided/libfixkalman) C library.
 cargo run --example fixed --features=fixed
 ```
 
-To disable floating-point support, run
+### Gravity Constant Estimation Example
+
+To run the example [`gravity`] simulation, run either
 
 ```shell
-cargo run --example fixed --no-default-features --features=fixed
-```
-
-### `f32`/`f64` floating-point
-
-The provided example code will print output only on `float` builds. Selecting this feature
-simply enables the following implementation for `f32` and `f64`:
-
-```rust
-impl MatrixDataType for f32 {
-    /// Calculates the reciprocal (inverse) of a number, i.e. `1/self`.
-    fn recip(self) -> Self {
-        self.recip()
-    }
-
-    /// Calculates the square root of a number.
-    fn square_root(self) -> Self {
-        self.sqrt()
-    }
-}
-```
-
-To run the example [`gravity`] simulation, run
-
-```shell
-cargo run --example gravity --features=float,libm
-```
-
-or
-
-```shell
-cargo run --example gravity --features=float,std
+cargo run --example gravity --features=std
+cargo run --example gravity --features=std,libm
 ```
 
 This will estimate the (earth's) gravitational constant (g ≈ 9.807 m/s²) through observation

--- a/crates/minikalman-traits/Cargo.toml
+++ b/crates/minikalman-traits/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["float"]
+default = []
 std = ["num-traits/std", "alloc"]
-float = []
 fixed = ["dep:fixed", "fixed/num-traits"]
 libm = ["dep:libm", "num-traits/libm"]
 no_assert = []

--- a/crates/minikalman-traits/src/kalman/filter_trait.rs
+++ b/crates/minikalman-traits/src/kalman/filter_trait.rs
@@ -2,7 +2,7 @@ use crate::kalman::{
     InputCovarianceMatrix, InputCovarianceMatrixMut, InputMatrix, InputMatrixMut, InputVector,
     InputVectorMut, MeasurementObservationMatrix, MeasurementObservationMatrixMut,
     MeasurementProcessNoiseCovarianceMatrix, MeasurementVector, MeasurementVectorMut, StateVector,
-    SystemCovarianceMatrix, SystemMatrix, SystemMatrixMut,
+    StateVectorMut, SystemCovarianceMatrix, SystemMatrix, SystemMatrixMut,
 };
 
 pub trait KalmanFilter<const STATES: usize, T>:
@@ -118,7 +118,9 @@ pub trait KalmanFilterStateVector<const STATES: usize, T> {
     fn state_vector_ref(&self) -> &Self::StateVector;
 }
 
-pub trait KalmanFilterStateVectorMut<const STATES: usize, T> {
+pub trait KalmanFilterStateVectorMut<const STATES: usize, T>:
+    KalmanFilterStateVector<STATES, T>
+{
     type StateVectorMut: StateVector<STATES, T>;
 
     /// Gets a reference to the state vector x.
@@ -206,7 +208,7 @@ pub trait KalmanFilterInputApplyToFilter<const STATES: usize, T> {
     #[allow(non_snake_case)]
     fn apply_to<X, P>(&mut self, x: &mut X, P: &mut P)
     where
-        X: StateVector<STATES, T>,
+        X: StateVectorMut<STATES, T>,
         P: SystemCovarianceMatrix<STATES, T>;
 }
 
@@ -308,7 +310,7 @@ pub trait KalmanFilterMeasurementCorrectFilter<const STATES: usize, T> {
     #[allow(non_snake_case)]
     fn correct<X, P>(&mut self, x: &mut X, P: &mut P)
     where
-        X: StateVector<STATES, T>,
+        X: StateVectorMut<STATES, T>,
         P: SystemCovarianceMatrix<STATES, T>;
 }
 

--- a/crates/minikalman-traits/src/kalman/matrix_types.rs
+++ b/crates/minikalman-traits/src/kalman/matrix_types.rs
@@ -1,5 +1,5 @@
 use crate::matrix::{Matrix, MatrixMut};
-use std::ops::{Index, IndexMut};
+use core::ops::{Index, IndexMut};
 
 /// State vector.
 ///

--- a/crates/minikalman-traits/src/kalman/matrix_types.rs
+++ b/crates/minikalman-traits/src/kalman/matrix_types.rs
@@ -3,14 +3,21 @@ use core::ops::{Index, IndexMut};
 
 /// State vector.
 ///
-/// Always mutable
-pub trait StateVector<const STATES: usize, T = f32>:
-    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
-{
+/// Immutable variant. For a mutable variant, see [`StateVectorMut`].
+pub trait StateVector<const STATES: usize, T = f32>: AsRef<[T]> + Index<usize, Output = T> {
     type Target: Matrix<STATES, 1, T>;
-    type TargetMut: MatrixMut<STATES, 1, T>;
 
     fn as_matrix(&self) -> &Self::Target;
+}
+
+/// State vector.
+///
+/// Mutable variant. For an immutable variant, see [`StateVector`].
+pub trait StateVectorMut<const STATES: usize, T = f32>:
+    StateVector<STATES, T> + AsMut<[T]> + IndexMut<usize, Output = T>
+{
+    type TargetMut: MatrixMut<STATES, 1, T>;
+
     fn as_matrix_mut(&mut self) -> &mut Self::TargetMut;
 
     /// Applies a function to the state vector x.

--- a/crates/minikalman-traits/src/kalman/matrix_types.rs
+++ b/crates/minikalman-traits/src/kalman/matrix_types.rs
@@ -1,9 +1,12 @@
 use crate::matrix::{Matrix, MatrixMut};
+use std::ops::{Index, IndexMut};
 
 /// State vector.
 ///
 /// Always mutable
-pub trait StateVector<const STATES: usize, T = f32> {
+pub trait StateVector<const STATES: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<STATES, 1, T>;
     type TargetMut: MatrixMut<STATES, 1, T>;
 
@@ -23,7 +26,9 @@ pub trait StateVector<const STATES: usize, T = f32> {
 /// System matrix.
 ///
 /// Immutable variant. For a mutable variant, see [`SystemMatrixMut`].
-pub trait SystemMatrix<const STATES: usize, T = f32> {
+pub trait SystemMatrix<const STATES: usize, T = f32>:
+    AsRef<[T]> + Index<usize, Output = T>
+{
     type Target: Matrix<STATES, STATES, T>;
 
     fn as_matrix(&self) -> &Self::Target;
@@ -32,7 +37,9 @@ pub trait SystemMatrix<const STATES: usize, T = f32> {
 /// System matrix.
 ///
 /// Mutable variant. For an immutable variant, see [`SystemMatrix`].
-pub trait SystemMatrixMut<const STATES: usize, T = f32>: SystemMatrix<STATES, T> {
+pub trait SystemMatrixMut<const STATES: usize, T = f32>:
+    SystemMatrix<STATES, T> + AsMut<[T]> + IndexMut<usize, Output = T>
+{
     type TargetMut: MatrixMut<STATES, STATES, T>;
 
     fn as_matrix_mut(&mut self) -> &mut Self::TargetMut;
@@ -50,7 +57,9 @@ pub trait SystemMatrixMut<const STATES: usize, T = f32>: SystemMatrix<STATES, T>
 /// System covariance matrix.
 ///
 /// Always mutable.
-pub trait SystemCovarianceMatrix<const STATES: usize, T = f32> {
+pub trait SystemCovarianceMatrix<const STATES: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<STATES, STATES, T>;
     type TargetMut: MatrixMut<STATES, STATES, T>;
 
@@ -70,7 +79,7 @@ pub trait SystemCovarianceMatrix<const STATES: usize, T = f32> {
 /// Input vector.
 ///
 /// Immutable variant. For a mutable variant, see [`InputVectorMut`].
-pub trait InputVector<const INPUTS: usize, T = f32> {
+pub trait InputVector<const INPUTS: usize, T = f32>: AsRef<[T]> + Index<usize, Output = T> {
     type Target: Matrix<INPUTS, 1, T>;
 
     fn as_matrix(&self) -> &Self::Target;
@@ -79,7 +88,9 @@ pub trait InputVector<const INPUTS: usize, T = f32> {
 /// Input vector.
 ///
 /// Mutable variant. For an immutable variant, see [`InputVector`].
-pub trait InputVectorMut<const INPUTS: usize, T = f32>: InputVector<INPUTS, T> {
+pub trait InputVectorMut<const INPUTS: usize, T = f32>:
+    InputVector<INPUTS, T> + AsMut<[T]> + IndexMut<usize, Output = T>
+{
     type TargetMut: MatrixMut<INPUTS, 1, T>;
 
     fn as_matrix_mut(&mut self) -> &mut Self::TargetMut;
@@ -97,7 +108,9 @@ pub trait InputVectorMut<const INPUTS: usize, T = f32>: InputVector<INPUTS, T> {
 /// Input matrix.
 ///
 /// Immutable variant. For a mutable variant, see [`InputMatrixMut`].
-pub trait InputMatrix<const STATES: usize, const INPUTS: usize, T = f32> {
+pub trait InputMatrix<const STATES: usize, const INPUTS: usize, T = f32>:
+    AsRef<[T]> + Index<usize, Output = T>
+{
     type Target: Matrix<STATES, INPUTS, T>;
 
     fn as_matrix(&self) -> &Self::Target;
@@ -107,7 +120,7 @@ pub trait InputMatrix<const STATES: usize, const INPUTS: usize, T = f32> {
 ///
 /// Mutable variant. For an immutable variant, see [`InputMatrix`].
 pub trait InputMatrixMut<const STATES: usize, const INPUTS: usize, T = f32>:
-    InputMatrix<STATES, INPUTS, T>
+    InputMatrix<STATES, INPUTS, T> + AsMut<[T]> + IndexMut<usize, Output = T>
 {
     type TargetMut: MatrixMut<STATES, INPUTS, T>;
 
@@ -126,7 +139,9 @@ pub trait InputMatrixMut<const STATES: usize, const INPUTS: usize, T = f32>:
 /// Input covariance matrix.
 ///
 /// Immutable variant. For a mutable variant, see [`InputCovarianceMatrixMut`].
-pub trait InputCovarianceMatrix<const INPUTS: usize, T = f32> {
+pub trait InputCovarianceMatrix<const INPUTS: usize, T = f32>:
+    AsRef<[T]> + Index<usize, Output = T>
+{
     type Target: Matrix<INPUTS, INPUTS, T>;
 
     fn as_matrix(&self) -> &Self::Target;
@@ -136,7 +151,7 @@ pub trait InputCovarianceMatrix<const INPUTS: usize, T = f32> {
 ///
 /// Mutable variant. For an immutable variant, see [`InputCovarianceMatrix`].
 pub trait InputCovarianceMatrixMut<const INPUTS: usize, T = f32>:
-    InputCovarianceMatrix<INPUTS, T>
+    InputCovarianceMatrix<INPUTS, T> + AsMut<[T]> + IndexMut<usize, Output = T>
 {
     type TargetMut: MatrixMut<INPUTS, INPUTS, T>;
 
@@ -156,7 +171,9 @@ pub trait InputCovarianceMatrixMut<const INPUTS: usize, T = f32>:
 /// x-sized temporary vector.
 ///
 /// Always mutable.
-pub trait StatePredictionVector<const STATES: usize, T = f32> {
+pub trait StatePredictionVector<const STATES: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<STATES, 1, T>;
     type TargetMut: MatrixMut<STATES, 1, T>;
 
@@ -167,7 +184,9 @@ pub trait StatePredictionVector<const STATES: usize, T = f32> {
 /// P-Sized temporary matrix (number of states × number of states).
 ///
 /// Always mutable.
-pub trait TemporaryStateMatrix<const STATES: usize, T = f32> {
+pub trait TemporaryStateMatrix<const STATES: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<STATES, STATES, T>;
     type TargetMut: MatrixMut<STATES, STATES, T>;
 
@@ -178,7 +197,9 @@ pub trait TemporaryStateMatrix<const STATES: usize, T = f32> {
 /// B×Q-sized temporary matrix (number of states × number of inputs).
 ///
 /// Always mutable.
-pub trait TemporaryBQMatrix<const STATES: usize, const INPUTS: usize, T = f32> {
+pub trait TemporaryBQMatrix<const STATES: usize, const INPUTS: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<STATES, INPUTS, T>;
     type TargetMut: MatrixMut<STATES, INPUTS, T>;
 
@@ -189,7 +210,9 @@ pub trait TemporaryBQMatrix<const STATES: usize, const INPUTS: usize, T = f32> {
 /// Measurement vector.
 ///
 /// Immutable variant. For a mutable variant, see [`MeasurementVectorMut`].
-pub trait MeasurementVector<const MEASUREMENTS: usize, T = f32> {
+pub trait MeasurementVector<const MEASUREMENTS: usize, T = f32>:
+    AsRef<[T]> + Index<usize, Output = T>
+{
     type Target: Matrix<MEASUREMENTS, 1, T>;
 
     fn as_matrix(&self) -> &Self::Target;
@@ -199,7 +222,7 @@ pub trait MeasurementVector<const MEASUREMENTS: usize, T = f32> {
 ///
 /// Mutable variant. For a immutable variant, see [`MeasurementVector`].
 pub trait MeasurementVectorMut<const MEASUREMENTS: usize, T = f32>:
-    MeasurementVector<MEASUREMENTS, T>
+    MeasurementVector<MEASUREMENTS, T> + AsMut<[T]> + IndexMut<usize, Output = T>
 {
     type TargetMut: MatrixMut<MEASUREMENTS, 1, T>;
 
@@ -218,7 +241,9 @@ pub trait MeasurementVectorMut<const MEASUREMENTS: usize, T = f32>:
 /// Measurement transformation matrix.
 ///
 /// Immutable variant. For a mutable variant, see [`MeasurementObservationMatrixMut`].
-pub trait MeasurementObservationMatrix<const MEASUREMENTS: usize, const STATES: usize, T = f32> {
+pub trait MeasurementObservationMatrix<const MEASUREMENTS: usize, const STATES: usize, T = f32>:
+    AsRef<[T]> + Index<usize, Output = T>
+{
     type Target: Matrix<MEASUREMENTS, STATES, T>;
 
     fn as_matrix(&self) -> &Self::Target;
@@ -228,7 +253,7 @@ pub trait MeasurementObservationMatrix<const MEASUREMENTS: usize, const STATES: 
 ///
 /// Mutable variant. For a immutable variant, see [`MeasurementObservationMatrix`].
 pub trait MeasurementObservationMatrixMut<const MEASUREMENTS: usize, const STATES: usize, T = f32>:
-    MeasurementObservationMatrix<MEASUREMENTS, STATES, T>
+    MeasurementObservationMatrix<MEASUREMENTS, STATES, T> + AsMut<[T]> + IndexMut<usize, Output = T>
 {
     type TargetMut: MatrixMut<MEASUREMENTS, STATES, T>;
 
@@ -247,7 +272,9 @@ pub trait MeasurementObservationMatrixMut<const MEASUREMENTS: usize, const STATE
 /// Measurement process noise covariance matrix.
 ///
 /// Always mutable.
-pub trait MeasurementProcessNoiseCovarianceMatrix<const MEASUREMENTS: usize, T = f32> {
+pub trait MeasurementProcessNoiseCovarianceMatrix<const MEASUREMENTS: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<MEASUREMENTS, MEASUREMENTS, T>;
     type TargetMut: MatrixMut<MEASUREMENTS, MEASUREMENTS, T>;
 
@@ -267,7 +294,9 @@ pub trait MeasurementProcessNoiseCovarianceMatrix<const MEASUREMENTS: usize, T =
 /// Innovation vector.
 ///
 /// Always mutable.
-pub trait InnovationVector<const MEASUREMENTS: usize, T = f32> {
+pub trait InnovationVector<const MEASUREMENTS: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<MEASUREMENTS, 1, T>;
     type TargetMut: MatrixMut<MEASUREMENTS, 1, T>;
 
@@ -278,7 +307,9 @@ pub trait InnovationVector<const MEASUREMENTS: usize, T = f32> {
 /// Residual covariance matrix.
 ///
 /// Always mutable.
-pub trait ResidualCovarianceMatrix<const MEASUREMENTS: usize, T = f32> {
+pub trait ResidualCovarianceMatrix<const MEASUREMENTS: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<MEASUREMENTS, MEASUREMENTS, T>;
     type TargetMut: MatrixMut<MEASUREMENTS, MEASUREMENTS, T>;
 
@@ -289,7 +320,9 @@ pub trait ResidualCovarianceMatrix<const MEASUREMENTS: usize, T = f32> {
 /// Kalman Gain matrix.
 ///
 /// Always mutable.
-pub trait KalmanGainMatrix<const STATES: usize, const MEASUREMENTS: usize, T = f32> {
+pub trait KalmanGainMatrix<const STATES: usize, const MEASUREMENTS: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<STATES, MEASUREMENTS, T>;
     type TargetMut: MatrixMut<STATES, MEASUREMENTS, T>;
 
@@ -300,7 +333,9 @@ pub trait KalmanGainMatrix<const STATES: usize, const MEASUREMENTS: usize, T = f
 /// Temporary residual covariance-inverted matrix.
 ///
 /// Always mutable.
-pub trait TemporaryResidualCovarianceInvertedMatrix<const MEASUREMENTS: usize, T = f32> {
+pub trait TemporaryResidualCovarianceInvertedMatrix<const MEASUREMENTS: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<MEASUREMENTS, MEASUREMENTS, T>;
     type TargetMut: MatrixMut<MEASUREMENTS, MEASUREMENTS, T>;
 
@@ -311,7 +346,9 @@ pub trait TemporaryResidualCovarianceInvertedMatrix<const MEASUREMENTS: usize, T
 /// Temporary measurement transformation matrix.
 ///
 /// Always mutable.
-pub trait TemporaryHPMatrix<const MEASUREMENTS: usize, const STATES: usize, T = f32> {
+pub trait TemporaryHPMatrix<const MEASUREMENTS: usize, const STATES: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<MEASUREMENTS, STATES, T>;
     type TargetMut: MatrixMut<MEASUREMENTS, STATES, T>;
 
@@ -322,7 +359,9 @@ pub trait TemporaryHPMatrix<const MEASUREMENTS: usize, const STATES: usize, T = 
 /// Temporary system covariance matrix.
 ///
 /// Always mutable.
-pub trait TemporaryKHPMatrix<const STATES: usize, T = f32> {
+pub trait TemporaryKHPMatrix<const STATES: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<STATES, STATES, T>;
     type TargetMut: MatrixMut<STATES, STATES, T>;
 
@@ -333,7 +372,9 @@ pub trait TemporaryKHPMatrix<const STATES: usize, T = f32> {
 /// P×H'-Sized (H'-Sized) temporary matrix  (number of states × number of measurements).
 ///
 /// Always mutable.
-pub trait TemporaryPHTMatrix<const STATES: usize, const MEASUREMENTS: usize, T = f32> {
+pub trait TemporaryPHTMatrix<const STATES: usize, const MEASUREMENTS: usize, T = f32>:
+    AsRef<[T]> + AsMut<[T]> + Index<usize, Output = T> + IndexMut<usize, Output = T>
+{
     type Target: Matrix<STATES, MEASUREMENTS, T>;
     type TargetMut: MatrixMut<STATES, MEASUREMENTS, T>;
 

--- a/crates/minikalman-traits/src/matrix/data.rs
+++ b/crates/minikalman-traits/src/matrix/data.rs
@@ -600,6 +600,13 @@ mod tests {
     }
 
     #[test]
+    fn data_into_array() {
+        let value: MatrixDataArray<4, 1, 4, f32> = [0.0, 1.0, 3.0, 4.0].into();
+        let data: [f32; 4] = value.into();
+        assert_eq!(data, [0.0, 1.0, 3.0, 4.0]);
+    }
+
+    #[test]
     #[rustfmt::skip]
     fn ref_from_mut() {
         let mut a_buf = [

--- a/crates/minikalman-traits/src/matrix/data.rs
+++ b/crates/minikalman-traits/src/matrix/data.rs
@@ -9,12 +9,12 @@ pub struct MatrixData;
 
 impl MatrixData {
     /// Creates an empty matrix.
-    pub fn empty<T>() -> MatrixDataOwned<0, 0, 0, T>
+    pub fn empty<T>() -> MatrixDataArray<0, 0, 0, T>
     where
         T: Default,
     {
         let nothing = [T::default(); 0];
-        MatrixDataOwned::<0, 0, 0, T>(nothing)
+        MatrixDataArray::<0, 0, 0, T>(nothing)
     }
 
     /// Creates a new matrix buffer that owns the data.
@@ -41,10 +41,10 @@ impl MatrixData {
     }
 
     /// Creates a new matrix buffer that owns the data.
-    pub const fn new_owned<const ROWS: usize, const COLS: usize, const TOTAL: usize, T>(
+    pub const fn new_array<const ROWS: usize, const COLS: usize, const TOTAL: usize, T>(
         data: [T; TOTAL],
-    ) -> MatrixDataOwned<ROWS, COLS, TOTAL, T> {
-        MatrixDataOwned::<ROWS, COLS, TOTAL, T>::new_unchecked(data)
+    ) -> MatrixDataArray<ROWS, COLS, TOTAL, T> {
+        MatrixDataArray::<ROWS, COLS, TOTAL, T>::new_unchecked(data)
     }
 
     /// Creates a new matrix buffer that references the data.
@@ -69,7 +69,7 @@ impl MatrixData {
 /// * `COLS` - The number of matrix columns.
 /// * `TOTAL` - The total number of matrix cells (i.e., rows × columns)
 /// * `T` - The data type.
-pub struct MatrixDataOwned<const ROWS: usize, const COLS: usize, const TOTAL: usize, T = f32>(
+pub struct MatrixDataArray<const ROWS: usize, const COLS: usize, const TOTAL: usize, T = f32>(
     [T; TOTAL],
 );
 
@@ -109,9 +109,9 @@ pub trait IntoInnerData {
 }
 
 impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T>
-    MatrixDataOwned<ROWS, COLS, TOTAL, T>
+    MatrixDataArray<ROWS, COLS, TOTAL, T>
 {
-    /// Creates a new instance of the [`MatrixDataOwned`] type.
+    /// Creates a new instance of the [`MatrixDataArray`] type.
     pub fn new(data: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
@@ -120,7 +120,7 @@ impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T>
         Self(data)
     }
 
-    /// Creates a new instance of the [`MatrixDataOwned`] type.
+    /// Creates a new instance of the [`MatrixDataArray`] type.
     pub const fn new_unchecked(data: [T; TOTAL]) -> Self {
         Self(data)
     }
@@ -178,7 +178,7 @@ impl<'a, const ROWS: usize, const COLS: usize, T> MatrixDataMut<'a, ROWS, COLS, 
 }
 
 impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T> IntoInnerData
-    for MatrixDataOwned<ROWS, COLS, TOTAL, T>
+    for MatrixDataArray<ROWS, COLS, TOTAL, T>
 {
     type Target = [T; TOTAL];
 
@@ -218,7 +218,7 @@ impl<'a, const ROWS: usize, const COLS: usize, T> IntoInnerData
 }
 
 impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
-    for MatrixDataOwned<ROWS, COLS, TOTAL, T>
+    for MatrixDataArray<ROWS, COLS, TOTAL, T>
 {
     fn from(value: [T; TOTAL]) -> Self {
         Self::new(value)
@@ -261,17 +261,17 @@ impl<'a, const ROWS: usize, const COLS: usize, T> From<&'a mut [T]>
 }
 
 impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T> Matrix<ROWS, COLS, T>
-    for MatrixDataOwned<ROWS, COLS, TOTAL, T>
+    for MatrixDataArray<ROWS, COLS, TOTAL, T>
 {
 }
 
 impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T> MatrixMut<ROWS, COLS, T>
-    for MatrixDataOwned<ROWS, COLS, TOTAL, T>
+    for MatrixDataArray<ROWS, COLS, TOTAL, T>
 {
 }
 
 impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T> AsRef<[T]>
-    for MatrixDataOwned<ROWS, COLS, TOTAL, T>
+    for MatrixDataArray<ROWS, COLS, TOTAL, T>
 {
     fn as_ref(&self) -> &[T] {
         &self.0
@@ -279,7 +279,7 @@ impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T> AsRef<[T]>
 }
 
 impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T> AsMut<[T]>
-    for MatrixDataOwned<ROWS, COLS, TOTAL, T>
+    for MatrixDataArray<ROWS, COLS, TOTAL, T>
 {
     fn as_mut(&mut self) -> &mut [T] {
         &mut self.0
@@ -350,7 +350,7 @@ impl<'a, const ROWS: usize, const COLS: usize, T> AsMut<[T]> for MatrixDataMut<'
 }
 
 impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T> Index<usize>
-    for MatrixDataOwned<ROWS, COLS, TOTAL, T>
+    for MatrixDataArray<ROWS, COLS, TOTAL, T>
 {
     type Output = T;
 
@@ -360,7 +360,7 @@ impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T> Index<usize>
 }
 
 impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T> IndexMut<usize>
-    for MatrixDataOwned<ROWS, COLS, TOTAL, T>
+    for MatrixDataArray<ROWS, COLS, TOTAL, T>
 {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -414,9 +414,9 @@ impl<'a, const ROWS: usize, const COLS: usize, T> IndexMut<usize>
 }
 
 impl<const ROWS: usize, const COLS: usize, const TOTAL: usize, T>
-    From<MatrixDataOwned<ROWS, COLS, TOTAL, T>> for [T; TOTAL]
+    From<MatrixDataArray<ROWS, COLS, TOTAL, T>> for [T; TOTAL]
 {
-    fn from(value: MatrixDataOwned<ROWS, COLS, TOTAL, T>) -> Self {
+    fn from(value: MatrixDataArray<ROWS, COLS, TOTAL, T>) -> Self {
         value.0
     }
 }
@@ -459,7 +459,7 @@ mod tests {
         let a_buf = [
             1.0, 2.0, 3.0,
             4.0, 5.0, 6.0];
-        let mut a = MatrixData::new_owned::<2, 3, 6, f32>(a_buf);
+        let mut a = MatrixData::new_array::<2, 3, 6, f32>(a_buf);
         a[2] += 10.0;
 
         assert_f32_near!(a[0], 1.);

--- a/crates/minikalman-traits/src/matrix/data_type.rs
+++ b/crates/minikalman-traits/src/matrix/data_type.rs
@@ -49,6 +49,7 @@ impl<T> MatrixDataTypeBase for T where
 {
 }
 
+#[cfg(any(feature = "std", feature = "libm"))]
 impl MatrixDataType for f32 {
     /// Calculates the reciprocal (inverse) of a number, i.e. `1/self`.
     fn recip(self) -> Self {
@@ -56,10 +57,8 @@ impl MatrixDataType for f32 {
         {
             1.0 / self
         }
-        #[cfg(not(feature = "libm"))]
+        #[cfg(feature = "std")]
         {
-            #[allow(unused)]
-            use num_traits::Float;
             self.recip()
         }
     }
@@ -70,15 +69,14 @@ impl MatrixDataType for f32 {
         {
             libm::sqrtf(self)
         }
-        #[cfg(not(feature = "libm"))]
+        #[cfg(feature = "std")]
         {
-            #[allow(unused)]
-            use num_traits::Float;
             self.sqrt()
         }
     }
 }
 
+#[cfg(any(feature = "std", feature = "libm"))]
 impl MatrixDataType for f64 {
     /// Calculates the reciprocal (inverse) of a number, i.e. `1/self`.
     fn recip(self) -> Self {
@@ -86,10 +84,8 @@ impl MatrixDataType for f64 {
         {
             1.0 / self
         }
-        #[cfg(not(feature = "libm"))]
+        #[cfg(feature = "std")]
         {
-            #[allow(unused)]
-            use num_traits::Float;
             self.recip()
         }
     }
@@ -100,10 +96,8 @@ impl MatrixDataType for f64 {
         {
             libm::sqrt(self)
         }
-        #[cfg(not(feature = "libm"))]
+        #[cfg(feature = "std")]
         {
-            #[allow(unused)]
-            use num_traits::Float;
             self.sqrt()
         }
     }

--- a/crates/minikalman-traits/src/matrix/data_type.rs
+++ b/crates/minikalman-traits/src/matrix/data_type.rs
@@ -53,25 +53,25 @@ impl<T> MatrixDataTypeBase for T where
 impl MatrixDataType for f32 {
     /// Calculates the reciprocal (inverse) of a number, i.e. `1/self`.
     fn recip(self) -> Self {
-        #[cfg(feature = "libm")]
-        {
-            1.0 / self
-        }
         #[cfg(feature = "std")]
         {
             self.recip()
+        }
+        #[cfg(not(feature = "std"))] // libm
+        {
+            1.0 / self
         }
     }
 
     /// Calculates the square root of a number.
     fn square_root(self) -> Self {
-        #[cfg(feature = "libm")]
-        {
-            libm::sqrtf(self)
-        }
         #[cfg(feature = "std")]
         {
             self.sqrt()
+        }
+        #[cfg(not(feature = "std"))] // libm
+        {
+            libm::sqrtf(self)
         }
     }
 }
@@ -80,25 +80,25 @@ impl MatrixDataType for f32 {
 impl MatrixDataType for f64 {
     /// Calculates the reciprocal (inverse) of a number, i.e. `1/self`.
     fn recip(self) -> Self {
-        #[cfg(feature = "libm")]
-        {
-            1.0 / self
-        }
         #[cfg(feature = "std")]
         {
             self.recip()
+        }
+        #[cfg(not(feature = "std"))] // libm
+        {
+            1.0 / self
         }
     }
 
     /// Calculates the square root of a number.
     fn square_root(self) -> Self {
-        #[cfg(feature = "libm")]
-        {
-            libm::sqrt(self)
-        }
         #[cfg(feature = "std")]
         {
             self.sqrt()
+        }
+        #[cfg(not(feature = "std"))] // libm
+        {
+            libm::sqrt(self)
         }
     }
 }

--- a/crates/minikalman-traits/src/matrix/data_type.rs
+++ b/crates/minikalman-traits/src/matrix/data_type.rs
@@ -49,8 +49,6 @@ impl<T> MatrixDataTypeBase for T where
 {
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "float")))]
-#[cfg(feature = "float")]
 impl MatrixDataType for f32 {
     /// Calculates the reciprocal (inverse) of a number, i.e. `1/self`.
     fn recip(self) -> Self {
@@ -81,8 +79,6 @@ impl MatrixDataType for f32 {
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "float")))]
-#[cfg(feature = "float")]
 impl MatrixDataType for f64 {
     /// Calculates the reciprocal (inverse) of a number, i.e. `1/self`.
     fn recip(self) -> Self {

--- a/crates/minikalman-traits/src/matrix/traits.rs
+++ b/crates/minikalman-traits/src/matrix/traits.rs
@@ -154,7 +154,7 @@ pub trait Matrix<const ROWS: usize, const COLS: usize, T = f32>:
     ///
     /// ## Example
     /// ```
-    /// use minikalman_traits::{MatrixData, Matrix};
+    /// use minikalman_traits::matrix::{Matrix, MatrixData};
     ///
     /// let a_buf = [
     ///      1.0, 2.0, 3.0,
@@ -237,7 +237,7 @@ pub trait Matrix<const ROWS: usize, const COLS: usize, T = f32>:
     ///
     /// ## Example
     /// ```
-    /// use minikalman_traits::{MatrixData, Matrix};
+    /// use minikalman_traits::matrix::{MatrixData, Matrix};
     ///
     /// let a_buf = [
     ///      1.0, 2.0, 3.0,
@@ -893,8 +893,7 @@ pub trait MatrixMut<const ROWS: usize, const COLS: usize, T = f32>:
     ///
     /// ## Example
     /// ```
-    /// use minikalman::MatrixData;
-    /// use minikalman::prelude::MatrixMut;
+    /// use minikalman_traits::matrix::{MatrixData, MatrixMut};
     ///
     /// // data buffer for the original and decomposed matrix
     /// let mut d = [
@@ -978,7 +977,7 @@ pub trait MatrixMut<const ROWS: usize, const COLS: usize, T = f32>:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::MatrixData;
+    use crate::matrix::MatrixData;
     use assert_float_eq::*;
 
     #[test]

--- a/crates/minikalman-traits/src/matrix/traits.rs
+++ b/crates/minikalman-traits/src/matrix/traits.rs
@@ -990,7 +990,7 @@ mod tests {
             10.0, 11.0,
             20.0, 21.0,
             30.0, 31.0];
-        let a = MatrixData::new_owned::<2, 3, 6, f32>(a_buf);
+        let a = MatrixData::new_array::<2, 3, 6, f32>(a_buf);
         let b = MatrixData::new_ref::<3, 2, f32>(&b_buf);
 
         let mut c_buf = [0f32; 2 * 2];
@@ -1143,7 +1143,7 @@ mod tests {
         let a = MatrixData::new_ref::<2, 3, f32>(&a_buf);
         let b = MatrixData::new_ref::<2, 3, f32>(&b_buf);
 
-        let mut c = MatrixData::new_owned::<2, 2, 4, f32>([0f32; 2 * 2]);
+        let mut c = MatrixData::new_array::<2, 2, 4, f32>([0f32; 2 * 2]);
         a.multscale_transb(&b, 2.0, &mut c);
 
         let c_buf = c.as_ref();

--- a/crates/minikalman-traits/src/matrix/traits.rs
+++ b/crates/minikalman-traits/src/matrix/traits.rs
@@ -27,9 +27,19 @@ pub trait Matrix<const ROWS: usize, const COLS: usize, T = f32>:
         ROWS * COLS
     }
 
+    /// Gets the number of elements in the underlying buffer..
+    fn buffer_len(&self) -> usize {
+        self.as_ref().len()
+    }
+
     /// Determines if this matrix has zero elements.
     fn is_empty(&self) -> bool {
         ROWS * COLS == 0
+    }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    fn is_valid(&self) -> bool {
+        self.len() <= self.buffer_len()
     }
 
     /// Gets a matrix element

--- a/crates/minikalman/Cargo.toml
+++ b/crates/minikalman/Cargo.toml
@@ -22,7 +22,6 @@ harness = false
 [[bench]]
 name = "gravity"
 harness = false
-required-features = ["float"]
 
 [[bench]]
 name = "gravity_fixed"
@@ -32,7 +31,7 @@ required-features = ["fixed"]
 [[example]]
 name = "gravity"
 path = "examples/gravity.rs"
-required-features = ["float", "std", "alloc"]
+required-features = ["std", "alloc"]
 
 [[example]]
 name = "fixed"
@@ -40,10 +39,9 @@ path = "examples/gravity_fixed.rs"
 required-features = ["fixed", "std", "alloc"]
 
 [features]
-default = ["float", "libm", "alloc", "minikalman-traits/default"]
+default = ["libm", "alloc", "minikalman-traits/default"]
 std = ["num-traits/std", "alloc", "minikalman-traits/std"]
 libm = ["dep:libm", "num-traits/libm", "minikalman-traits/libm"]
-float = ["minikalman-traits/float"]
 unsafe = []
 fixed = ["dep:fixed", "fixed/num-traits", "minikalman-traits/fixed"]
 no_assert = ["minikalman-traits/no_assert"]

--- a/crates/minikalman/benches/gravity.rs
+++ b/crates/minikalman/benches/gravity.rs
@@ -57,7 +57,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             SystemMatrixMutBuffer::from(gravity_A.as_mut()),
             StateVectorBuffer::from(gravity_x.as_mut()),
             SystemCovarianceMatrixBuffer::from(gravity_P.as_mut()),
-            StatePredictionVectorBuffer::from(gravity_temp_x.as_mut()),
+            TemporaryStatePredictionVectorBuffer::from(gravity_temp_x.as_mut()),
             TemporaryStateMatrixBuffer::from(gravity_temp_P.as_mut()),
         );
 
@@ -99,7 +99,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             SystemMatrixMutBuffer::from(gravity_A.as_mut()),
             StateVectorBuffer::from(gravity_x.as_mut()),
             SystemCovarianceMatrixBuffer::from(gravity_P.as_mut()),
-            StatePredictionVectorBuffer::from(gravity_temp_x.as_mut()),
+            TemporaryStatePredictionVectorBuffer::from(gravity_temp_x.as_mut()),
             TemporaryStateMatrixBuffer::from(gravity_temp_P.as_mut()),
         );
 
@@ -135,7 +135,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             SystemMatrixMutBuffer::from(gravity_A.as_mut()),
             StateVectorBuffer::from(gravity_x.as_mut()),
             SystemCovarianceMatrixBuffer::from(gravity_P.as_mut()),
-            StatePredictionVectorBuffer::from(gravity_temp_x.as_mut()),
+            TemporaryStatePredictionVectorBuffer::from(gravity_temp_x.as_mut()),
             TemporaryStateMatrixBuffer::from(gravity_temp_P.as_mut()),
         );
 
@@ -172,7 +172,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 }
 
 /// Initializes the state vector with initial assumptions.
-fn initialize_state_vector(filter: &mut impl StateVector<NUM_STATES, f32>) {
+fn initialize_state_vector(filter: &mut impl StateVectorMut<NUM_STATES, f32>) {
     filter.apply(|state| {
         state[0] = 0 as _; // position
         state[1] = 0 as _; // velocity

--- a/crates/minikalman/benches/gravity_fixed.rs
+++ b/crates/minikalman/benches/gravity_fixed.rs
@@ -4,10 +4,10 @@ use lazy_static::lazy_static;
 use minikalman::buffer_types::{
     InnovationResidualCovarianceMatrixBuffer, InnovationVectorBuffer, KalmanGainMatrixBuffer,
     MeasurementObservationMatrixMutBuffer, MeasurementProcessNoiseCovarianceMatrixBuffer,
-    MeasurementVectorBuffer, StatePredictionVectorBuffer, StateVectorBuffer,
-    SystemCovarianceMatrixBuffer, SystemMatrixMutBuffer, TemporaryHPMatrixBuffer,
-    TemporaryKHPMatrixBuffer, TemporaryPHTMatrixBuffer,
-    TemporaryResidualCovarianceInvertedMatrixBuffer, TemporaryStateMatrixBuffer,
+    MeasurementVectorBuffer, StateVectorBuffer, SystemCovarianceMatrixBuffer,
+    SystemMatrixMutBuffer, TemporaryHPMatrixBuffer, TemporaryKHPMatrixBuffer,
+    TemporaryPHTMatrixBuffer, TemporaryResidualCovarianceInvertedMatrixBuffer,
+    TemporaryStateMatrixBuffer, TemporaryStatePredictionVectorBuffer,
 };
 use minikalman::prelude::{fixed::I16F16, *};
 use minikalman_traits::kalman::*;
@@ -106,7 +106,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             SystemMatrixMutBuffer::from(gravity_A.as_mut()),
             StateVectorBuffer::from(gravity_x.as_mut()),
             SystemCovarianceMatrixBuffer::from(gravity_P.as_mut()),
-            StatePredictionVectorBuffer::from(gravity_temp_x.as_mut()),
+            TemporaryStatePredictionVectorBuffer::from(gravity_temp_x.as_mut()),
             TemporaryStateMatrixBuffer::from(gravity_temp_P.as_mut()),
         );
 
@@ -148,7 +148,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             SystemMatrixMutBuffer::from(gravity_A.as_mut()),
             StateVectorBuffer::from(gravity_x.as_mut()),
             SystemCovarianceMatrixBuffer::from(gravity_P.as_mut()),
-            StatePredictionVectorBuffer::from(gravity_temp_x.as_mut()),
+            TemporaryStatePredictionVectorBuffer::from(gravity_temp_x.as_mut()),
             TemporaryStateMatrixBuffer::from(gravity_temp_P.as_mut()),
         );
 
@@ -184,7 +184,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             SystemMatrixMutBuffer::from(gravity_A.as_mut()),
             StateVectorBuffer::from(gravity_x.as_mut()),
             SystemCovarianceMatrixBuffer::from(gravity_P.as_mut()),
-            StatePredictionVectorBuffer::from(gravity_temp_x.as_mut()),
+            TemporaryStatePredictionVectorBuffer::from(gravity_temp_x.as_mut()),
             TemporaryStateMatrixBuffer::from(gravity_temp_P.as_mut()),
         );
 

--- a/crates/minikalman/benches/inversion.rs
+++ b/crates/minikalman/benches/inversion.rs
@@ -14,10 +14,10 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("invert_lower (owned)", |bencher| {
         let a_buf = [1.0f32, 0.0, 0.0, -2.0, 1.0, 0.0, 3.5, -2.5, 1.0];
-        let a = MatrixData::new_owned::<3, 3, 9, f32>(a_buf);
+        let a = MatrixData::new_array::<3, 3, 9, f32>(a_buf);
 
         let inv_buf = [0f32; 3 * 3];
-        let mut inv = MatrixData::new_owned::<3, 3, 9, f32>(inv_buf);
+        let mut inv = MatrixData::new_array::<3, 3, 9, f32>(inv_buf);
 
         bencher.iter(|| a.invert_l_cholesky(black_box(&mut inv)))
     });

--- a/crates/minikalman/examples/gravity.rs
+++ b/crates/minikalman/examples/gravity.rs
@@ -9,6 +9,7 @@
 #[allow(unused)]
 use colored::Colorize;
 
+use minikalman::builder::KalmanFilterBuilder;
 use rand_distr::{Distribution, Normal};
 
 use minikalman::prelude::*;
@@ -19,63 +20,10 @@ const NUM_MEASUREMENTS: usize = 1; // position
 
 #[allow(non_snake_case)]
 fn main() {
-    // System buffers.
-    let gravity_x = BufferBuilder::state_vector_x::<NUM_STATES>().new(0.0_f32);
-    let gravity_A = BufferBuilder::system_state_transition_A::<NUM_STATES>().new(0.0_f32);
-    let gravity_P = BufferBuilder::system_covariance_P::<NUM_STATES>().new(0.0_f32);
-
-    // Input buffers.
-    let gravity_u = BufferBuilder::input_vector_u::<NUM_INPUTS>().new(0.0_f32);
-    let gravity_B = BufferBuilder::input_transition_B::<NUM_STATES, NUM_INPUTS>().new(0.0_f32);
-    let gravity_Q = BufferBuilder::input_covariance_Q::<NUM_INPUTS>().new(0.0_f32);
-
-    // Measurement buffers.
-    let gravity_z = BufferBuilder::measurement_vector_z::<NUM_MEASUREMENTS>().new(0.0_f32);
-    let gravity_H =
-        BufferBuilder::measurement_transformation_H::<NUM_MEASUREMENTS, NUM_STATES>().new(0.0_f32);
-    let gravity_R = BufferBuilder::measurement_covariance_R::<NUM_MEASUREMENTS>().new(0.0_f32);
-    let gravity_y = BufferBuilder::innovation_vector_y::<NUM_MEASUREMENTS>().new(0.0_f32);
-    let gravity_S = BufferBuilder::innovation_covariance_S::<NUM_MEASUREMENTS>().new(0.0_f32);
-    let gravity_K = BufferBuilder::kalman_gain_K::<NUM_STATES, NUM_MEASUREMENTS>().new(0.0_f32);
-
-    // Filter temporaries.
-    let gravity_temp_x = BufferBuilder::state_prediction_temp_x::<NUM_STATES>().new(0.0_f32);
-    let gravity_temp_P = BufferBuilder::temp_system_covariance_P::<NUM_STATES>().new(0.0_f32);
-    let gravity_temp_BQ = BufferBuilder::temp_BQ::<NUM_STATES, NUM_INPUTS>().new(0.0_f32);
-
-    // Measurement temporaries.
-    let gravity_temp_S_inv = BufferBuilder::temp_S_inv::<NUM_MEASUREMENTS>().new(0.0_f32);
-    let gravity_temp_HP = BufferBuilder::temp_HP::<NUM_MEASUREMENTS, NUM_STATES>().new(0.0_f32);
-    let gravity_temp_PHt = BufferBuilder::temp_PHt::<NUM_STATES, NUM_MEASUREMENTS>().new(0.0_f32);
-    let gravity_temp_KHP = BufferBuilder::temp_KHP::<NUM_STATES>().new(0.0_f32);
-
-    let mut filter = KalmanBuilder::new::<NUM_STATES, f32>(
-        gravity_A,
-        gravity_x,
-        gravity_P,
-        gravity_temp_x,
-        gravity_temp_P,
-    );
-
-    let mut input = InputBuilder::new::<NUM_STATES, NUM_INPUTS, f32>(
-        gravity_B,
-        gravity_u,
-        gravity_Q,
-        gravity_temp_BQ,
-    );
-
-    let mut measurement = MeasurementBuilder::new::<NUM_STATES, NUM_MEASUREMENTS, f32>(
-        gravity_H,
-        gravity_z,
-        gravity_R,
-        gravity_y,
-        gravity_S,
-        gravity_K,
-        gravity_temp_S_inv,
-        gravity_temp_HP,
-        gravity_temp_PHt,
-        gravity_temp_KHP,
-    );
+    let builder = KalmanFilterBuilder::<NUM_STATES, f32>::default();
+    let mut filter = builder.build();
+    let mut measurement = builder.measurements().build::<NUM_MEASUREMENTS>();
+    let mut input = builder.inputs().build::<NUM_INPUTS>();
 
     // Set initial state.
     initialize_state_vector(filter.state_vector_mut());
@@ -120,7 +68,7 @@ fn main() {
 
     // Fetch estimated gravity constant.
     let gravity_x = filter.state_vector_ref();
-    let g_estimated = gravity_x.get(0, 2);
+    let g_estimated = gravity_x.as_matrix().get(0, 2);
     assert!(g_estimated > 9.0 && g_estimated < 10.0);
 }
 

--- a/crates/minikalman/examples/gravity.rs
+++ b/crates/minikalman/examples/gravity.rs
@@ -105,7 +105,7 @@ fn generate_error(n: usize) -> Vec<f32> {
 }
 
 /// Initializes the state vector with initial assumptions.
-fn initialize_state_vector(filter: &mut impl StateVector<NUM_STATES, f32>) {
+fn initialize_state_vector(filter: &mut impl StateVectorMut<NUM_STATES, f32>) {
     filter.apply(|state| {
         state[0] = 0 as _; // position
         state[1] = 0 as _; // velocity

--- a/crates/minikalman/examples/gravity.rs
+++ b/crates/minikalman/examples/gravity.rs
@@ -22,8 +22,8 @@ const NUM_MEASUREMENTS: usize = 1; // position
 fn main() {
     let builder = KalmanFilterBuilder::<NUM_STATES, f32>::default();
     let mut filter = builder.build();
-    let mut measurement = builder.measurements().build::<NUM_MEASUREMENTS>();
     let mut input = builder.inputs().build::<NUM_INPUTS>();
+    let mut measurement = builder.measurements().build::<NUM_MEASUREMENTS>();
 
     // Set initial state.
     initialize_state_vector(filter.state_vector_mut());

--- a/crates/minikalman/examples/gravity_fixed.rs
+++ b/crates/minikalman/examples/gravity_fixed.rs
@@ -9,6 +9,7 @@
 #[allow(unused)]
 use colored::Colorize;
 use lazy_static::lazy_static;
+use minikalman::builder::KalmanFilterBuilder;
 
 use minikalman::prelude::*;
 
@@ -68,53 +69,9 @@ lazy_static! {
 
 #[allow(non_snake_case)]
 fn main() {
-    // System buffers.
-    let gravity_x = BufferBuilder::state_vector_x::<NUM_STATES>().new(I16F16::ZERO);
-    let gravity_A = BufferBuilder::system_state_transition_A::<NUM_STATES>().new(I16F16::ZERO);
-    let gravity_P = BufferBuilder::system_covariance_P::<NUM_STATES>().new(I16F16::ZERO);
-
-    // Measurement buffers.
-    let gravity_z = BufferBuilder::measurement_vector_z::<NUM_MEASUREMENTS>().new(I16F16::ZERO);
-    let gravity_H = BufferBuilder::measurement_transformation_H::<NUM_MEASUREMENTS, NUM_STATES>()
-        .new(I16F16::ZERO);
-    let gravity_R = BufferBuilder::measurement_covariance_R::<NUM_MEASUREMENTS>().new(I16F16::ZERO);
-    let gravity_y = BufferBuilder::innovation_vector_y::<NUM_MEASUREMENTS>().new(I16F16::ZERO);
-    let gravity_S = BufferBuilder::innovation_covariance_S::<NUM_MEASUREMENTS>().new(I16F16::ZERO);
-    let gravity_K =
-        BufferBuilder::kalman_gain_K::<NUM_STATES, NUM_MEASUREMENTS>().new(I16F16::ZERO);
-
-    // Filter temporaries.
-    let gravity_temp_x = BufferBuilder::state_prediction_temp_x::<NUM_STATES>().new(I16F16::ZERO);
-    let gravity_temp_P = BufferBuilder::temp_system_covariance_P::<NUM_STATES>().new(I16F16::ZERO);
-
-    // Measurement temporaries.
-    let gravity_temp_S_inv = BufferBuilder::temp_S_inv::<NUM_MEASUREMENTS>().new(I16F16::ZERO);
-    let gravity_temp_HP =
-        BufferBuilder::temp_HP::<NUM_MEASUREMENTS, NUM_STATES>().new(I16F16::ZERO);
-    let gravity_temp_PHt =
-        BufferBuilder::temp_PHt::<NUM_STATES, NUM_MEASUREMENTS>().new(I16F16::ZERO);
-    let gravity_temp_KHP = BufferBuilder::temp_KHP::<NUM_STATES>().new(I16F16::ZERO);
-
-    let mut filter = KalmanBuilder::new::<NUM_STATES, I16F16>(
-        gravity_A,
-        gravity_x,
-        gravity_P,
-        gravity_temp_x,
-        gravity_temp_P,
-    );
-
-    let mut measurement = MeasurementBuilder::new::<NUM_STATES, NUM_MEASUREMENTS, I16F16>(
-        gravity_H,
-        gravity_z,
-        gravity_R,
-        gravity_y,
-        gravity_S,
-        gravity_K,
-        gravity_temp_S_inv,
-        gravity_temp_HP,
-        gravity_temp_PHt,
-        gravity_temp_KHP,
-    );
+    let builder = KalmanFilterBuilder::<NUM_STATES, I16F16>::default();
+    let mut filter = builder.build();
+    let mut measurement = builder.measurements().build::<NUM_MEASUREMENTS>();
 
     // Set initial state.
     initialize_state_vector(filter.state_vector_mut());

--- a/crates/minikalman/examples/gravity_fixed.rs
+++ b/crates/minikalman/examples/gravity_fixed.rs
@@ -105,7 +105,7 @@ fn main() {
 }
 
 /// Initializes the state vector with initial assumptions.
-fn initialize_state_vector(filter: &mut impl StateVector<NUM_STATES, I16F16>) {
+fn initialize_state_vector(filter: &mut impl StateVectorMut<NUM_STATES, I16F16>) {
     filter.apply(|state| {
         state[0] = I16F16::ZERO; // position
         state[1] = I16F16::ZERO; // velocity

--- a/crates/minikalman/src/buffer_builder.rs
+++ b/crates/minikalman/src/buffer_builder.rs
@@ -173,6 +173,12 @@ pub struct TemporaryPHtMatrixBufferBuilder<const STATES: usize, const MEASUREMEN
 /// A builder for temporary K×(H×P) sized matrices (`num_states` × `num_states`).
 pub struct TemporaryKHPMatrixBufferBuilder<const STATES: usize>;
 
+/// The type of owned state vector buffers.
+#[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type StateVectorBufferOwnedType<const STATES: usize, T> =
+    StateVectorBuffer<STATES, T, MatrixDataOwned<STATES, 1, STATES, T>>;
+
 impl<const STATES: usize> StateVectorBufferBuilder<STATES> {
     /// Builds a new [`StateVectorBufferBuilder`] that owns its data.
     ///
@@ -188,10 +194,7 @@ impl<const STATES: usize> StateVectorBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> StateVectorBuffer<STATES, T, MatrixDataOwned<STATES, 1, STATES, T>>
+    pub fn new<T>(&self, init: T) -> StateVectorBufferOwnedType<STATES, T>
     where
         T: Copy,
     {
@@ -200,6 +203,12 @@ impl<const STATES: usize> StateVectorBufferBuilder<STATES> {
         )
     }
 }
+
+/// The type of owned state transition matrix buffers.
+#[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type SystemMatrixMutBufferOwnedType<const STATES: usize, T> =
+    SystemMatrixMutBuffer<STATES, T, MatrixDataBoxed<STATES, STATES, T>>;
 
 impl<const STATES: usize> StateTransitionMatrixBufferBuilder<STATES> {
     /// Builds a new [`SystemMatrixMutBuffer`] that owns its data.
@@ -216,10 +225,7 @@ impl<const STATES: usize> StateTransitionMatrixBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> SystemMatrixMutBuffer<STATES, T, MatrixDataBoxed<STATES, STATES, T>>
+    pub fn new<T>(&self, init: T) -> SystemMatrixMutBufferOwnedType<STATES, T>
     where
         T: Copy,
     {
@@ -228,6 +234,12 @@ impl<const STATES: usize> StateTransitionMatrixBufferBuilder<STATES> {
         )
     }
 }
+
+/// The type of owned state transition matrix buffers.
+#[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type SystemCovarianceMatrixBufferOwnedType<const STATES: usize, T> =
+    SystemCovarianceMatrixBuffer<STATES, T, MatrixDataBoxed<STATES, STATES, T>>;
 
 impl<const STATES: usize> SystemCovarianceMatrixBufferBuilder<STATES> {
     /// Builds a new [`SystemCovarianceMatrixBuffer`] that owns its data.
@@ -244,10 +256,7 @@ impl<const STATES: usize> SystemCovarianceMatrixBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> SystemCovarianceMatrixBuffer<STATES, T, MatrixDataBoxed<STATES, STATES, T>>
+    pub fn new<T>(&self, init: T) -> SystemCovarianceMatrixBufferOwnedType<STATES, T>
     where
         T: Copy,
     {
@@ -544,6 +553,12 @@ impl<const STATES: usize, const MEASUREMENTS: usize>
     }
 }
 
+/// The type of owned state vector buffers.
+#[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type StatePredictionVectorBufferOwnedType<const STATES: usize, T> =
+    StatePredictionVectorBuffer<STATES, T, MatrixDataOwned<STATES, 1, STATES, T>>;
+
 impl<const STATES: usize> StatePredictionVectorBufferBuilder<STATES> {
     /// Builds a new [`StatePredictionVectorBuffer`] that owns its data.
     ///
@@ -572,6 +587,12 @@ impl<const STATES: usize> StatePredictionVectorBufferBuilder<STATES> {
     }
 }
 
+/// The type of owned state transition matrix buffers.
+#[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type TemporarySystemCovarianceMatrixBufferOwnedType<const STATES: usize, T> =
+    TemporaryStateMatrixBuffer<STATES, T, MatrixDataBoxed<STATES, STATES, T>>;
+
 impl<const STATES: usize> TemporarySystemCovarianceMatrixBufferBuilder<STATES> {
     /// Builds a new [`TemporaryStateMatrixBuffer`] that owns its data.
     ///
@@ -587,10 +608,7 @@ impl<const STATES: usize> TemporarySystemCovarianceMatrixBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> TemporaryStateMatrixBuffer<STATES, T, MatrixDataBoxed<STATES, STATES, T>>
+    pub fn new<T>(&self, init: T) -> TemporarySystemCovarianceMatrixBufferOwnedType<STATES, T>
     where
         T: Copy,
     {

--- a/crates/minikalman/src/buffer_builder.rs
+++ b/crates/minikalman/src/buffer_builder.rs
@@ -362,6 +362,11 @@ impl<const INPUTS: usize> InputCovarianceMatrixBufferBuilder<INPUTS> {
     }
 }
 
+/// The type of observation vector buffers.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type ObservationVectorBufferOwnedType<const MEASUREMENTS: usize, T> =
+    MeasurementVectorBuffer<MEASUREMENTS, T, MatrixDataArray<MEASUREMENTS, 1, MEASUREMENTS, T>>;
+
 impl<const MEASUREMENTS: usize> MeasurementVectorBufferBuilder<MEASUREMENTS> {
     /// Builds a new [`MeasurementVectorBuffer`] that owns its data.
     ///
@@ -377,10 +382,7 @@ impl<const MEASUREMENTS: usize> MeasurementVectorBufferBuilder<MEASUREMENTS> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> MeasurementVectorBuffer<MEASUREMENTS, T, MatrixDataArray<MEASUREMENTS, 1, MEASUREMENTS, T>>
+    pub fn new<T>(&self, init: T) -> ObservationVectorBufferOwnedType<MEASUREMENTS, T>
     where
         T: Copy,
     {
@@ -389,6 +391,16 @@ impl<const MEASUREMENTS: usize> MeasurementVectorBufferBuilder<MEASUREMENTS> {
         )
     }
 }
+
+/// The type of observation matrix buffers.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type ObservationMatrixBufferOwnedType<const MEASUREMENTS: usize, const STATES: usize, T> =
+    MeasurementObservationMatrixMutBuffer<
+        MEASUREMENTS,
+        STATES,
+        T,
+        MatrixDataBoxed<MEASUREMENTS, STATES, T>,
+    >;
 
 impl<const MEASUREMENTS: usize, const STATES: usize>
     MeasurementTransformationMatrixBufferBuilder<MEASUREMENTS, STATES>
@@ -407,15 +419,7 @@ impl<const MEASUREMENTS: usize, const STATES: usize>
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> MeasurementObservationMatrixMutBuffer<
-        MEASUREMENTS,
-        STATES,
-        T,
-        MatrixDataBoxed<MEASUREMENTS, STATES, T>,
-    >
+    pub fn new<T>(&self, init: T) -> ObservationMatrixBufferOwnedType<MEASUREMENTS, STATES, T>
     where
         T: Copy,
     {
@@ -429,6 +433,15 @@ impl<const MEASUREMENTS: usize, const STATES: usize>
         ))
     }
 }
+
+/// The type of observation / process noise covariance matrix buffers.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type ObservationCovarianceBufferOwnedType<const MEASUREMENTS: usize, T> =
+    MeasurementProcessNoiseCovarianceMatrixBuffer<
+        MEASUREMENTS,
+        T,
+        MatrixDataBoxed<MEASUREMENTS, MEASUREMENTS, T>,
+    >;
 
 impl<const MEASUREMENTS: usize> MeasurementProcessNoiseCovarianceMatrixBufferBuilder<MEASUREMENTS> {
     /// Builds a new [`MeasurementProcessNoiseCovarianceMatrixBuffer`] that owns its data.
@@ -445,14 +458,7 @@ impl<const MEASUREMENTS: usize> MeasurementProcessNoiseCovarianceMatrixBufferBui
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> MeasurementProcessNoiseCovarianceMatrixBuffer<
-        MEASUREMENTS,
-        T,
-        MatrixDataBoxed<MEASUREMENTS, MEASUREMENTS, T>,
-    >
+    pub fn new<T>(&self, init: T) -> ObservationCovarianceBufferOwnedType<MEASUREMENTS, T>
     where
         T: Copy,
     {
@@ -465,6 +471,11 @@ impl<const MEASUREMENTS: usize> MeasurementProcessNoiseCovarianceMatrixBufferBui
         ))
     }
 }
+
+/// The type of innovation vector buffers.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type InnovationVectorBufferOwnedType<const MEASUREMENTS: usize, T> =
+    InnovationVectorBuffer<MEASUREMENTS, T, MatrixDataArray<MEASUREMENTS, 1, MEASUREMENTS, T>>;
 
 impl<const MEASUREMENTS: usize> InnovationVectorBufferBuilder<MEASUREMENTS> {
     /// Builds a new [`InnovationVectorBuffer`] that owns its data.
@@ -481,10 +492,7 @@ impl<const MEASUREMENTS: usize> InnovationVectorBufferBuilder<MEASUREMENTS> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> InnovationVectorBuffer<MEASUREMENTS, T, MatrixDataArray<MEASUREMENTS, 1, MEASUREMENTS, T>>
+    pub fn new<T>(&self, init: T) -> InnovationVectorBufferOwnedType<MEASUREMENTS, T>
     where
         T: Copy,
     {
@@ -493,6 +501,15 @@ impl<const MEASUREMENTS: usize> InnovationVectorBufferBuilder<MEASUREMENTS> {
         )
     }
 }
+
+/// The type of innovation residual covariance matrix buffers.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type InnovationResidualCovarianceMatrixBufferOwnedType<const MEASUREMENTS: usize, T> =
+    InnovationResidualCovarianceMatrixBuffer<
+        MEASUREMENTS,
+        T,
+        MatrixDataBoxed<MEASUREMENTS, MEASUREMENTS, T>,
+    >;
 
 impl<const MEASUREMENTS: usize> InnovationResidualCovarianceMatrixBufferBuilder<MEASUREMENTS> {
     /// Builds a new [`InnovationResidualCovarianceMatrixBuffer`] that owns its data.
@@ -512,11 +529,7 @@ impl<const MEASUREMENTS: usize> InnovationResidualCovarianceMatrixBufferBuilder<
     pub fn new<T>(
         &self,
         init: T,
-    ) -> InnovationResidualCovarianceMatrixBuffer<
-        MEASUREMENTS,
-        T,
-        MatrixDataBoxed<MEASUREMENTS, MEASUREMENTS, T>,
-    >
+    ) -> InnovationResidualCovarianceMatrixBufferOwnedType<MEASUREMENTS, T>
     where
         T: Copy,
     {
@@ -529,6 +542,11 @@ impl<const MEASUREMENTS: usize> InnovationResidualCovarianceMatrixBufferBuilder<
         ))
     }
 }
+
+/// The type of innovation residual covariance matrix buffers.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type KalmanGainMatrixBufferOwnedType<const STATES: usize, const MEASUREMENTS: usize, T> =
+    KalmanGainMatrixBuffer<STATES, MEASUREMENTS, T, MatrixDataBoxed<STATES, MEASUREMENTS, T>>;
 
 impl<const STATES: usize, const MEASUREMENTS: usize>
     KalmanGainMatrixBufferBuilder<STATES, MEASUREMENTS>
@@ -547,10 +565,7 @@ impl<const STATES: usize, const MEASUREMENTS: usize>
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> KalmanGainMatrixBuffer<STATES, MEASUREMENTS, T, MatrixDataBoxed<STATES, MEASUREMENTS, T>>
+    pub fn new<T>(&self, init: T) -> KalmanGainMatrixBufferOwnedType<STATES, MEASUREMENTS, T>
     where
         T: Copy,
     {
@@ -585,10 +600,7 @@ impl<const STATES: usize> StatePredictionVectorBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> TemporaryStatePredictionVectorBuffer<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>
+    pub fn new<T>(&self, init: T) -> TemporaryStatePredictionVectorBufferOwnedType<STATES, T>
     where
         T: Copy,
     {
@@ -648,10 +660,7 @@ impl<const STATES: usize, const INPUTS: usize> TemporaryBQMatrixBufferBuilder<ST
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> TemporaryBQMatrixBuffer<STATES, INPUTS, T, MatrixDataBoxed<STATES, INPUTS, T>>
+    pub fn new<T>(&self, init: T) -> TemporaryBQMatrixBufferOwnedType<STATES, INPUTS, T>
     where
         T: Copy,
     {
@@ -660,6 +669,15 @@ impl<const STATES: usize, const INPUTS: usize> TemporaryBQMatrixBufferBuilder<ST
         )
     }
 }
+
+/// The type of temporary S-inverted matrix buffers.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type TemporarySInvertedMatrixBufferOwnedType<const MEASUREMENTS: usize, T> =
+    TemporaryResidualCovarianceInvertedMatrixBuffer<
+        MEASUREMENTS,
+        T,
+        MatrixDataBoxed<MEASUREMENTS, MEASUREMENTS, T>,
+    >;
 
 impl<const MEASUREMENTS: usize> TemporarySInvMatrixBufferBuilder<MEASUREMENTS> {
     /// Builds a new [`TemporaryResidualCovarianceInvertedMatrixBuffer`] that owns its data.
@@ -676,14 +694,7 @@ impl<const MEASUREMENTS: usize> TemporarySInvMatrixBufferBuilder<MEASUREMENTS> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> TemporaryResidualCovarianceInvertedMatrixBuffer<
-        MEASUREMENTS,
-        T,
-        MatrixDataBoxed<MEASUREMENTS, MEASUREMENTS, T>,
-    >
+    pub fn new<T>(&self, init: T) -> TemporarySInvertedMatrixBufferOwnedType<MEASUREMENTS, T>
     where
         T: Copy,
     {
@@ -696,6 +707,11 @@ impl<const MEASUREMENTS: usize> TemporarySInvMatrixBufferBuilder<MEASUREMENTS> {
         ))
     }
 }
+
+/// The type of temporary H×P matrix buffers, tandem to [`TemporaryPHtMatrixBufferOwnedType`].
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type TemporaryHPMatrixBufferOwnedType<const MEASUREMENTS: usize, const STATES: usize, T> =
+    TemporaryHPMatrixBuffer<MEASUREMENTS, STATES, T, MatrixDataBoxed<MEASUREMENTS, STATES, T>>;
 
 impl<const MEASUREMENTS: usize, const STATES: usize>
     TemporaryHPMatrixBufferBuilder<MEASUREMENTS, STATES>
@@ -714,10 +730,7 @@ impl<const MEASUREMENTS: usize, const STATES: usize>
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> TemporaryHPMatrixBuffer<MEASUREMENTS, STATES, T, MatrixDataBoxed<MEASUREMENTS, STATES, T>>
+    pub fn new<T>(&self, init: T) -> TemporaryHPMatrixBufferOwnedType<MEASUREMENTS, STATES, T>
     where
         T: Copy,
     {
@@ -731,6 +744,11 @@ impl<const MEASUREMENTS: usize, const STATES: usize>
         ))
     }
 }
+
+/// The type of temporary P×Hᵀ matrix buffers, tandem to [`TemporaryHPMatrixBufferOwnedType`].
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type TemporaryPHtMatrixBufferOwnedType<const STATES: usize, const MEASUREMENTS: usize, T> =
+    TemporaryPHTMatrixBuffer<STATES, MEASUREMENTS, T, MatrixDataBoxed<STATES, MEASUREMENTS, T>>;
 
 impl<const STATES: usize, const MEASUREMENTS: usize>
     TemporaryPHtMatrixBufferBuilder<STATES, MEASUREMENTS>
@@ -749,10 +767,7 @@ impl<const STATES: usize, const MEASUREMENTS: usize>
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> TemporaryPHTMatrixBuffer<STATES, MEASUREMENTS, T, MatrixDataBoxed<STATES, MEASUREMENTS, T>>
+    pub fn new<T>(&self, init: T) -> TemporaryPHtMatrixBufferOwnedType<STATES, MEASUREMENTS, T>
     where
         T: Copy,
     {
@@ -766,6 +781,11 @@ impl<const STATES: usize, const MEASUREMENTS: usize>
         ))
     }
 }
+
+/// The type of temporary K×H×P matrix buffers.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type TemporaryKHPMatrixBufferOwnedType<const STATES: usize, T> =
+    TemporaryKHPMatrixBuffer<STATES, T, MatrixDataBoxed<STATES, STATES, T>>;
 
 impl<const STATES: usize> TemporaryKHPMatrixBufferBuilder<STATES> {
     /// Builds a new [`TemporaryKHPMatrixBuffer`] that owns its data.
@@ -782,10 +802,7 @@ impl<const STATES: usize> TemporaryKHPMatrixBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
-        &self,
-        init: T,
-    ) -> TemporaryKHPMatrixBuffer<STATES, T, MatrixDataBoxed<STATES, STATES, T>>
+    pub fn new<T>(&self, init: T) -> TemporaryKHPMatrixBufferOwnedType<STATES, T>
     where
         T: Copy,
     {

--- a/crates/minikalman/src/buffer_builder.rs
+++ b/crates/minikalman/src/buffer_builder.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use minikalman_traits::matrix::{MatrixData, MatrixDataBoxed, MatrixDataOwned};
+use minikalman_traits::matrix::{MatrixData, MatrixDataArray, MatrixDataBoxed};
 
 // TODO: Provide Kalman builder that returns impl KalmanFilter, or export a type alias e.g. via associated type.
 
@@ -177,7 +177,7 @@ pub struct TemporaryKHPMatrixBufferBuilder<const STATES: usize>;
 #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub type StateVectorBufferOwnedType<const STATES: usize, T> =
-    StateVectorBuffer<STATES, T, MatrixDataOwned<STATES, 1, STATES, T>>;
+    StateVectorBuffer<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>;
 
 impl<const STATES: usize> StateVectorBufferBuilder<STATES> {
     /// Builds a new [`StateVectorBufferBuilder`] that owns its data.
@@ -198,8 +198,8 @@ impl<const STATES: usize> StateVectorBufferBuilder<STATES> {
     where
         T: Copy,
     {
-        StateVectorBuffer::<STATES, T, MatrixDataOwned<STATES, 1, STATES, T>>::new(
-            MatrixData::new_owned::<STATES, 1, STATES, T>([init; STATES]),
+        StateVectorBuffer::<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>::new(
+            MatrixData::new_array::<STATES, 1, STATES, T>([init; STATES]),
         )
     }
 }
@@ -284,12 +284,12 @@ impl<const INPUTS: usize> InputVectorBufferBuilder<INPUTS> {
     pub fn new<T>(
         &self,
         init: T,
-    ) -> InputVectorBuffer<INPUTS, T, MatrixDataOwned<INPUTS, 1, INPUTS, T>>
+    ) -> InputVectorBuffer<INPUTS, T, MatrixDataArray<INPUTS, 1, INPUTS, T>>
     where
         T: Copy,
     {
-        InputVectorBuffer::<INPUTS, T, MatrixDataOwned<INPUTS, 1, INPUTS, T>>::new(
-            MatrixData::new_owned::<INPUTS, 1, INPUTS, T>([init; INPUTS]),
+        InputVectorBuffer::<INPUTS, T, MatrixDataArray<INPUTS, 1, INPUTS, T>>::new(
+            MatrixData::new_array::<INPUTS, 1, INPUTS, T>([init; INPUTS]),
         )
     }
 }
@@ -368,12 +368,12 @@ impl<const MEASUREMENTS: usize> MeasurementVectorBufferBuilder<MEASUREMENTS> {
     pub fn new<T>(
         &self,
         init: T,
-    ) -> MeasurementVectorBuffer<MEASUREMENTS, T, MatrixDataOwned<MEASUREMENTS, 1, MEASUREMENTS, T>>
+    ) -> MeasurementVectorBuffer<MEASUREMENTS, T, MatrixDataArray<MEASUREMENTS, 1, MEASUREMENTS, T>>
     where
         T: Copy,
     {
-        MeasurementVectorBuffer::<MEASUREMENTS, T, MatrixDataOwned<MEASUREMENTS, 1, MEASUREMENTS, T>>::new(
-            MatrixData::new_owned::<MEASUREMENTS, 1, MEASUREMENTS, T>([init; MEASUREMENTS]),
+        MeasurementVectorBuffer::<MEASUREMENTS, T, MatrixDataArray<MEASUREMENTS, 1, MEASUREMENTS, T>>::new(
+            MatrixData::new_array::<MEASUREMENTS, 1, MEASUREMENTS, T>([init; MEASUREMENTS]),
         )
     }
 }
@@ -472,12 +472,12 @@ impl<const MEASUREMENTS: usize> InnovationVectorBufferBuilder<MEASUREMENTS> {
     pub fn new<T>(
         &self,
         init: T,
-    ) -> InnovationVectorBuffer<MEASUREMENTS, T, MatrixDataOwned<MEASUREMENTS, 1, MEASUREMENTS, T>>
+    ) -> InnovationVectorBuffer<MEASUREMENTS, T, MatrixDataArray<MEASUREMENTS, 1, MEASUREMENTS, T>>
     where
         T: Copy,
     {
-        InnovationVectorBuffer::<MEASUREMENTS, T, MatrixDataOwned<MEASUREMENTS, 1, MEASUREMENTS, T>>::new(
-            MatrixData::new_owned::<MEASUREMENTS, 1, MEASUREMENTS, T>([init; MEASUREMENTS]),
+        InnovationVectorBuffer::<MEASUREMENTS, T, MatrixDataArray<MEASUREMENTS, 1, MEASUREMENTS, T>>::new(
+            MatrixData::new_array::<MEASUREMENTS, 1, MEASUREMENTS, T>([init; MEASUREMENTS]),
         )
     }
 }
@@ -556,11 +556,11 @@ impl<const STATES: usize, const MEASUREMENTS: usize>
 /// The type of owned state vector buffers.
 #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub type StatePredictionVectorBufferOwnedType<const STATES: usize, T> =
-    StatePredictionVectorBuffer<STATES, T, MatrixDataOwned<STATES, 1, STATES, T>>;
+pub type TemporaryStatePredictionVectorBufferOwnedType<const STATES: usize, T> =
+    TemporaryStatePredictionVectorBuffer<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>;
 
 impl<const STATES: usize> StatePredictionVectorBufferBuilder<STATES> {
-    /// Builds a new [`StatePredictionVectorBuffer`] that owns its data.
+    /// Builds a new [`TemporaryStatePredictionVectorBuffer`] that owns its data.
     ///
     /// ## Example
     /// ```
@@ -568,7 +568,7 @@ impl<const STATES: usize> StatePredictionVectorBufferBuilder<STATES> {
     ///
     /// let buffer = BufferBuilder::state_prediction_temp_x::<3>().new(0.0);
     ///
-    /// let buffer: StatePredictionVectorBuffer<3, f32, _> = buffer;
+    /// let buffer: TemporaryStatePredictionVectorBuffer<3, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 3);
     /// ```
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
@@ -577,12 +577,12 @@ impl<const STATES: usize> StatePredictionVectorBufferBuilder<STATES> {
     pub fn new<T>(
         &self,
         init: T,
-    ) -> StatePredictionVectorBuffer<STATES, T, MatrixDataOwned<STATES, 1, STATES, T>>
+    ) -> TemporaryStatePredictionVectorBuffer<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>
     where
         T: Copy,
     {
-        StatePredictionVectorBuffer::<STATES, T, MatrixDataOwned<STATES, 1, STATES, T>>::new(
-            MatrixData::new_owned::<STATES, 1, STATES, T>([init; STATES]),
+        TemporaryStatePredictionVectorBuffer::<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>::new(
+            MatrixData::new_array::<STATES, 1, STATES, T>([init; STATES]),
         )
     }
 }
@@ -590,7 +590,7 @@ impl<const STATES: usize> StatePredictionVectorBufferBuilder<STATES> {
 /// The type of owned state transition matrix buffers.
 #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-pub type TemporarySystemCovarianceMatrixBufferOwnedType<const STATES: usize, T> =
+pub type TemporaryStateMatrixBufferOwnedType<const STATES: usize, T> =
     TemporaryStateMatrixBuffer<STATES, T, MatrixDataBoxed<STATES, STATES, T>>;
 
 impl<const STATES: usize> TemporarySystemCovarianceMatrixBufferBuilder<STATES> {
@@ -608,7 +608,7 @@ impl<const STATES: usize> TemporarySystemCovarianceMatrixBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> TemporarySystemCovarianceMatrixBufferOwnedType<STATES, T>
+    pub fn new<T>(&self, init: T) -> TemporaryStateMatrixBufferOwnedType<STATES, T>
     where
         T: Copy,
     {

--- a/crates/minikalman/src/buffer_builder.rs
+++ b/crates/minikalman/src/buffer_builder.rs
@@ -174,7 +174,6 @@ pub struct TemporaryPHtMatrixBufferBuilder<const STATES: usize, const MEASUREMEN
 pub struct TemporaryKHPMatrixBufferBuilder<const STATES: usize>;
 
 /// The type of owned state vector buffers.
-#[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub type StateVectorBufferOwnedType<const STATES: usize, T> =
     StateVectorBuffer<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>;
@@ -205,7 +204,6 @@ impl<const STATES: usize> StateVectorBufferBuilder<STATES> {
 }
 
 /// The type of owned state transition matrix buffers.
-#[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub type SystemMatrixMutBufferOwnedType<const STATES: usize, T> =
     SystemMatrixMutBuffer<STATES, T, MatrixDataBoxed<STATES, STATES, T>>;
@@ -236,7 +234,6 @@ impl<const STATES: usize> StateTransitionMatrixBufferBuilder<STATES> {
 }
 
 /// The type of owned state transition matrix buffers.
-#[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub type SystemCovarianceMatrixBufferOwnedType<const STATES: usize, T> =
     SystemCovarianceMatrixBuffer<STATES, T, MatrixDataBoxed<STATES, STATES, T>>;
@@ -266,6 +263,11 @@ impl<const STATES: usize> SystemCovarianceMatrixBufferBuilder<STATES> {
     }
 }
 
+/// The type of owned control vector buffers.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type ControlVectorBufferOwnedType<const STATES: usize, T> =
+    InputVectorBuffer<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>;
+
 impl<const INPUTS: usize> InputVectorBufferBuilder<INPUTS> {
     /// Builds a new [`InputVectorBuffer`] that owns its data.
     ///
@@ -294,6 +296,11 @@ impl<const INPUTS: usize> InputVectorBufferBuilder<INPUTS> {
     }
 }
 
+/// The type of owned control matrix buffers.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type ControlMatrixBufferOwnedType<const STATES: usize, const INPUTS: usize, T> =
+    InputMatrixMutBuffer<STATES, INPUTS, T, MatrixDataBoxed<STATES, INPUTS, T>>;
+
 impl<const STATES: usize, const INPUTS: usize> InputTransitionMatrixBufferBuilder<STATES, INPUTS> {
     /// Builds a new [`InputMatrixMutBuffer`] that owns its data.
     ///
@@ -321,6 +328,11 @@ impl<const STATES: usize, const INPUTS: usize> InputTransitionMatrixBufferBuilde
         )
     }
 }
+
+/// The type of owned control matrix buffers.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type ControlCovarianceMatrixBufferOwnedType<const INPUTS: usize, T> =
+    InputCovarianceMatrixMutBuffer<INPUTS, T, MatrixDataBoxed<INPUTS, INPUTS, T>>;
 
 impl<const INPUTS: usize> InputCovarianceMatrixBufferBuilder<INPUTS> {
     /// Builds a new [`InputCovarianceMatrixMutBuffer`] that owns its data.
@@ -554,7 +566,6 @@ impl<const STATES: usize, const MEASUREMENTS: usize>
 }
 
 /// The type of owned state vector buffers.
-#[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub type TemporaryStatePredictionVectorBufferOwnedType<const STATES: usize, T> =
     TemporaryStatePredictionVectorBuffer<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>;
@@ -588,7 +599,6 @@ impl<const STATES: usize> StatePredictionVectorBufferBuilder<STATES> {
 }
 
 /// The type of owned state transition matrix buffers.
-#[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub type TemporaryStateMatrixBufferOwnedType<const STATES: usize, T> =
     TemporaryStateMatrixBuffer<STATES, T, MatrixDataBoxed<STATES, STATES, T>>;
@@ -617,6 +627,11 @@ impl<const STATES: usize> TemporarySystemCovarianceMatrixBufferBuilder<STATES> {
         )
     }
 }
+
+/// The type of temporary B×Q matrix buffers.
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub type TemporaryBQMatrixBufferOwnedType<const STATES: usize, const INPUTS: usize, T> =
+    TemporaryBQMatrixBuffer<STATES, INPUTS, T, MatrixDataBoxed<STATES, INPUTS, T>>;
 
 impl<const STATES: usize, const INPUTS: usize> TemporaryBQMatrixBufferBuilder<STATES, INPUTS> {
     /// Builds a new [`TemporaryBQMatrixBuffer`] that owns its data.

--- a/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
@@ -188,6 +188,7 @@ mod tests {
         let value: InnovationResidualCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
@@ -179,6 +179,7 @@ mod tests {
     fn test_from_array() {
         let value: InnovationResidualCovarianceMatrixBuffer<5, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -188,6 +189,7 @@ mod tests {
         let value: InnovationResidualCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
+        assert!(!value.is_empty());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }
 

--- a/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
@@ -77,6 +77,11 @@ where
     pub const fn is_empty(&self) -> bool {
         MEASUREMENTS == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const MEASUREMENTS: usize, T, M> AsRef<[T]>
@@ -163,5 +168,25 @@ where
 
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: InnovationResidualCovarianceMatrixBuffer<5, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: InnovationResidualCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
     }
 }

--- a/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
@@ -183,7 +183,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: InnovationResidualCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);

--- a/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::ResidualCovarianceMatrix;
 use minikalman_traits::matrix::{
-    IntoInnerData, Matrix, MatrixData, MatrixDataMut, MatrixDataOwned, MatrixMut,
+    IntoInnerData, Matrix, MatrixData, MatrixDataArray, MatrixDataMut, MatrixMut,
 };
 
 /// Buffer for the square innovation (residual) covariance matrix (`num_measurements` × `num_measurements`).
@@ -13,7 +13,7 @@ use minikalman_traits::matrix::{
 /// use minikalman_traits::matrix::MatrixData;
 ///
 /// // From owned data
-/// let buffer = InnovationResidualCovarianceMatrixBuffer::new(MatrixData::new_owned::<2, 2, 4, f32>([0.0; 4]));
+/// let buffer = InnovationResidualCovarianceMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
 ///
 /// // From a reference
 /// let mut data = [0.0; 4];
@@ -48,7 +48,7 @@ impl<const MEASUREMENTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     for InnovationResidualCovarianceMatrixBuffer<
         MEASUREMENTS,
         T,
-        MatrixDataOwned<MEASUREMENTS, MEASUREMENTS, TOTAL, T>,
+        MatrixDataArray<MEASUREMENTS, MEASUREMENTS, TOTAL, T>,
     >
 {
     fn from(value: [T; TOTAL]) -> Self {
@@ -56,7 +56,7 @@ impl<const MEASUREMENTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
         {
             debug_assert_eq!(MEASUREMENTS * MEASUREMENTS, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<MEASUREMENTS, MEASUREMENTS, TOTAL, T>(value))
+        Self::new(MatrixData::new_array::<MEASUREMENTS, MEASUREMENTS, TOTAL, T>(value))
     }
 }
 

--- a/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
@@ -38,7 +38,7 @@ impl<'a, const MEASUREMENTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * MEASUREMENTS, value.len());
+            debug_assert!(MEASUREMENTS * MEASUREMENTS <= value.len());
         }
         Self::new(MatrixData::new_mut::<MEASUREMENTS, MEASUREMENTS, T>(value))
     }
@@ -54,7 +54,7 @@ impl<const MEASUREMENTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * MEASUREMENTS, TOTAL);
+            debug_assert!(MEASUREMENTS * MEASUREMENTS <= TOTAL);
         }
         Self::new(MatrixData::new_array::<MEASUREMENTS, MEASUREMENTS, TOTAL, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_residual_covariance_matrix_buffer.rs
@@ -189,4 +189,11 @@ mod tests {
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
     }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: InnovationResidualCovarianceMatrixBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
+    }
 }

--- a/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
@@ -175,6 +175,7 @@ mod tests {
     fn test_from_array() {
         let value: InnovationVectorBuffer<5, f32, _> = [0.0; 5].into();
         assert_eq!(value.len(), 5);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -183,6 +184,7 @@ mod tests {
         let mut data = [0.0_f32; 5];
         let value: InnovationVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
@@ -17,7 +17,7 @@ impl<'a, const MEASUREMENTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS, value.len());
+            debug_assert!(MEASUREMENTS <= value.len());
         }
         Self::new(MatrixData::new_mut::<MEASUREMENTS, 1, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
@@ -184,5 +184,6 @@ mod tests {
         let value: InnovationVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 }

--- a/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
@@ -50,6 +50,11 @@ where
     pub const fn is_empty(&self) -> bool {
         MEASUREMENTS == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const MEASUREMENTS: usize, T, M> AsRef<[T]> for InnovationVectorBuffer<MEASUREMENTS, T, M>

--- a/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
@@ -179,7 +179,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 5];
         let value: InnovationVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);

--- a/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
@@ -5,6 +5,20 @@ use minikalman_traits::kalman::InnovationVector;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Mutable buffer for the innovation vector (`num_measurements` × `1`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = InnovationVectorBuffer::new(MatrixData::new_array::<4, 1, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = InnovationVectorBuffer::<2, f32, _>::from(data.as_mut());
+/// ```
 pub struct InnovationVectorBuffer<const MEASUREMENTS: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<MEASUREMENTS, 1, T>;

--- a/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
@@ -23,6 +23,20 @@ impl<'a, const MEASUREMENTS: usize, T> From<&'a mut [T]>
     }
 }
 
+/// # Example
+/// Buffers can be trivially constructed from correctly-sized arrays:
+///
+/// ```
+/// # use minikalman::prelude::InnovationVectorBuffer;
+/// let _value: InnovationVectorBuffer<5, f32, _> = [0.0; 5].into();
+/// ```
+///
+/// Invalid buffer sizes fail to compile:
+///
+/// ```fail_compile
+/// # use minikalman::prelude::InnovationVectorBuffer;
+/// let _value: InnovationVectorBuffer<5, f32, _> = [0.0; 1].into();
+/// ```
 impl<const MEASUREMENTS: usize, T> From<[T; MEASUREMENTS]>
     for InnovationVectorBuffer<MEASUREMENTS, T, MatrixDataArray<MEASUREMENTS, 1, MEASUREMENTS, T>>
 {
@@ -157,12 +171,4 @@ mod tests {
         assert_eq!(value.len(), 5);
         assert!(value.is_valid());
     }
-
-    /* TODO: Turn into compile_fail doctest
-    #[test]
-    fn test_from_array_invalid_size() {
-        let value: InnovationVectorBuffer<5, f32, _> = [0.0; 1].into();
-        assert!(!value.is_valid());
-    }
-    */
 }

--- a/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
@@ -138,3 +138,31 @@ where
         self.0.into_inner()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: InnovationVectorBuffer<5, f32, _> = [0.0; 5].into();
+        assert_eq!(value.len(), 5);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 5];
+        let value: InnovationVectorBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 5);
+        assert!(value.is_valid());
+    }
+
+    /* TODO: Turn into compile_fail doctest
+    #[test]
+    fn test_from_array_invalid_size() {
+        let value: InnovationVectorBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
+    }
+    */
+}

--- a/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/innovation_vector_buffer.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 
 use minikalman_traits::kalman::InnovationVector;
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct InnovationVectorBuffer<const MEASUREMENTS: usize, T, M>(M, PhantomData<T>)
@@ -24,10 +24,10 @@ impl<'a, const MEASUREMENTS: usize, T> From<&'a mut [T]>
 }
 
 impl<const MEASUREMENTS: usize, T> From<[T; MEASUREMENTS]>
-    for InnovationVectorBuffer<MEASUREMENTS, T, MatrixDataOwned<MEASUREMENTS, 1, MEASUREMENTS, T>>
+    for InnovationVectorBuffer<MEASUREMENTS, T, MatrixDataArray<MEASUREMENTS, 1, MEASUREMENTS, T>>
 {
     fn from(value: [T; MEASUREMENTS]) -> Self {
-        Self::new(MatrixData::new_owned::<MEASUREMENTS, 1, MEASUREMENTS, T>(
+        Self::new(MatrixData::new_array::<MEASUREMENTS, 1, MEASUREMENTS, T>(
             value,
         ))
     }

--- a/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
@@ -302,6 +302,7 @@ mod tests {
         let value: InputCovarianceMatrixBuffer<5, f32, _> = data.as_ref().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]
@@ -324,6 +325,7 @@ mod tests {
         let value: InputCovarianceMatrixMutBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
@@ -308,6 +308,16 @@ mod tests {
     }
 
     #[test]
+    fn test_from_mut() {
+        let mut data = [0.0_f32; 100];
+        let value: InputCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+        assert!(!value.is_empty());
+        assert!(core::ptr::eq(value.as_ref(), &data));
+    }
+
+    #[test]
     #[cfg(feature = "no_assert")]
     fn test_from_array_invalid_size() {
         let value: InputCovarianceMatrixBuffer<5, f32, _> = [0.0; 1].into();

--- a/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
@@ -1,5 +1,6 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
+
 use minikalman_traits::kalman::{InputCovarianceMatrix, InputCovarianceMatrixMut};
 use minikalman_traits::matrix::{
     IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut, MatrixDataRef,
@@ -241,5 +242,32 @@ where
 
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: InputCovarianceMatrixMutBuffer<5, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: InputCovarianceMatrixMutBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: InputCovarianceMatrixMutBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
     }
 }

--- a/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
@@ -293,6 +293,7 @@ mod tests {
     fn test_from_array() {
         let value: InputCovarianceMatrixBuffer<5, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -302,6 +303,7 @@ mod tests {
         let value: InputCovarianceMatrixBuffer<5, f32, _> = data.as_ref().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
+        assert!(!value.is_empty());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
@@ -316,6 +318,7 @@ mod tests {
     fn test_mut_from_array() {
         let value: InputCovarianceMatrixMutBuffer<5, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -324,6 +327,7 @@ mod tests {
         let mut data = [0.0_f32; 100];
         let value: InputCovarianceMatrixMutBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
@@ -17,6 +17,18 @@ where
 
 // -----------------------------------------------------------
 
+impl<const INPUTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
+    for InputCovarianceMatrixBuffer<INPUTS, T, MatrixDataArray<INPUTS, INPUTS, TOTAL, T>>
+{
+    fn from(value: [T; TOTAL]) -> Self {
+        #[cfg(not(feature = "no_assert"))]
+        {
+            debug_assert_eq!(INPUTS * INPUTS, TOTAL);
+        }
+        Self::new(MatrixData::new_array::<INPUTS, INPUTS, TOTAL, T>(value))
+    }
+}
+
 impl<'a, const INPUTS: usize, T> From<&'a [T]>
     for InputCovarianceMatrixBuffer<INPUTS, T, MatrixDataRef<'a, INPUTS, INPUTS, T>>
 {
@@ -251,13 +263,35 @@ mod tests {
 
     #[test]
     fn test_from_array() {
-        let value: InputCovarianceMatrixMutBuffer<5, f32, _> = [0.0; 100].into();
+        let value: InputCovarianceMatrixBuffer<5, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
     }
 
     #[test]
     fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: InputCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: InputCovarianceMatrixBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
+    }
+
+    #[test]
+    fn test_mut_from_array() {
+        let value: InputCovarianceMatrixMutBuffer<5, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_mut_from_ref() {
         let mut data = [0.0_f32; 100];
         let value: InputCovarianceMatrixMutBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
@@ -266,7 +300,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "no_assert")]
-    fn test_from_array_invalid_size() {
+    fn test_mut_from_array_invalid_size() {
         let value: InputCovarianceMatrixMutBuffer<5, f32, _> = [0.0; 1].into();
         assert!(!value.is_valid());
     }

--- a/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
@@ -126,6 +126,11 @@ where
     pub const fn is_empty(&self) -> bool {
         INPUTS == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const INPUTS: usize, T, M> AsRef<[T]> for InputCovarianceMatrixMutBuffer<INPUTS, T, M>

--- a/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
@@ -23,7 +23,7 @@ impl<const INPUTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(INPUTS * INPUTS, TOTAL);
+            debug_assert!(INPUTS * INPUTS <= TOTAL);
         }
         Self::new(MatrixData::new_array::<INPUTS, INPUTS, TOTAL, T>(value))
     }
@@ -35,7 +35,7 @@ impl<'a, const INPUTS: usize, T> From<&'a [T]>
     fn from(value: &'a [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(INPUTS * INPUTS, value.len());
+            debug_assert!(INPUTS * INPUTS <= value.len());
         }
         Self::new(MatrixData::new_ref::<INPUTS, INPUTS, T>(value))
     }
@@ -47,7 +47,7 @@ impl<'a, const INPUTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(INPUTS * INPUTS, value.len());
+            debug_assert!(INPUTS * INPUTS <= value.len());
         }
         Self::new(MatrixData::new_ref::<INPUTS, INPUTS, T>(value))
     }
@@ -59,7 +59,7 @@ impl<'a, const INPUTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(INPUTS * INPUTS, value.len());
+            debug_assert!(INPUTS * INPUTS <= value.len());
         }
         Self::new(MatrixData::new_mut::<INPUTS, INPUTS, T>(value))
     }
@@ -71,7 +71,7 @@ impl<const INPUTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(INPUTS * INPUTS, TOTAL);
+            debug_assert!(INPUTS * INPUTS <= TOTAL);
         }
         Self::new(MatrixData::new_array::<INPUTS, INPUTS, TOTAL, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
@@ -7,10 +7,38 @@ use minikalman_traits::matrix::{
 };
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Immutable buffer for the input covariance matrix (`num_inputs` × `num_inputs`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = InputCovarianceMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let data = [0.0; 4];
+/// let buffer = InputCovarianceMatrixBuffer::<2, f32, _>::from(data.as_ref());
+/// ```
 pub struct InputCovarianceMatrixBuffer<const INPUTS: usize, T, M>(M, PhantomData<T>)
 where
     M: Matrix<INPUTS, INPUTS, T>;
 
+/// Mutable buffer for the input covariance matrix (`num_inputs` × `num_inputs`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = InputCovarianceMatrixMutBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = InputCovarianceMatrixMutBuffer::<2, f32, _>::from(data.as_mut());
+/// ```
 pub struct InputCovarianceMatrixMutBuffer<const INPUTS: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<INPUTS, INPUTS, T>;

--- a/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
@@ -298,8 +298,8 @@ mod tests {
 
     #[test]
     fn test_from_ref() {
-        let mut data = [0.0_f32; 100];
-        let value: InputCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
+        let data = [0.0_f32; 100];
+        let value: InputCovarianceMatrixBuffer<5, f32, _> = data.as_ref().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
     }
@@ -319,7 +319,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mut_from_ref() {
+    fn test_mut_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: InputCovarianceMatrixMutBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);

--- a/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_covariance_buffer.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::{InputCovarianceMatrix, InputCovarianceMatrixMut};
 use minikalman_traits::matrix::{
-    IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned, MatrixDataRef,
+    IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut, MatrixDataRef,
 };
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -53,14 +53,14 @@ impl<'a, const INPUTS: usize, T> From<&'a mut [T]>
 }
 
 impl<const INPUTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
-    for InputCovarianceMatrixMutBuffer<INPUTS, T, MatrixDataOwned<INPUTS, INPUTS, TOTAL, T>>
+    for InputCovarianceMatrixMutBuffer<INPUTS, T, MatrixDataArray<INPUTS, INPUTS, TOTAL, T>>
 {
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
             debug_assert_eq!(INPUTS * INPUTS, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<INPUTS, INPUTS, TOTAL, T>(value))
+        Self::new(MatrixData::new_array::<INPUTS, INPUTS, TOTAL, T>(value))
     }
 }
 

--- a/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
@@ -301,6 +301,7 @@ mod tests {
     fn test_from_array() {
         let value: InputMatrixBuffer<5, 3, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -309,6 +310,7 @@ mod tests {
         let data = [0.0_f32; 100];
         let value: InputMatrixBuffer<5, 3, f32, _> = data.as_ref().into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }
@@ -324,6 +326,7 @@ mod tests {
     fn test_mut_from_array() {
         let value: InputMatrixMutBuffer<5, 3, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -332,6 +335,7 @@ mod tests {
         let mut data = [0.0_f32; 100];
         let value: InputMatrixMutBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
@@ -310,6 +310,7 @@ mod tests {
         let value: InputMatrixBuffer<5, 3, f32, _> = data.as_ref().into();
         assert_eq!(value.len(), 15);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]
@@ -332,6 +333,7 @@ mod tests {
         let value: InputMatrixMutBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
@@ -128,6 +128,11 @@ where
     pub const fn is_empty(&self) -> bool {
         STATES * INPUTS == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const STATES: usize, const INPUTS: usize, T, M> AsRef<[T]>

--- a/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
@@ -306,8 +306,8 @@ mod tests {
 
     #[test]
     fn test_from_ref() {
-        let mut data = [0.0_f32; 100];
-        let value: InputMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
+        let data = [0.0_f32; 100];
+        let value: InputMatrixBuffer<5, 3, f32, _> = data.as_ref().into();
         assert_eq!(value.len(), 15);
         assert!(value.is_valid());
     }
@@ -327,7 +327,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mut_from_ref() {
+    fn test_mut_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: InputMatrixMutBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);

--- a/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
@@ -3,7 +3,7 @@ use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::{InputMatrix, InputMatrixMut};
 
 use minikalman_traits::matrix::{
-    IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned, MatrixDataRef,
+    IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut, MatrixDataRef,
 };
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -54,14 +54,14 @@ impl<'a, const STATES: usize, const INPUTS: usize, T> From<&'a mut [T]>
 }
 
 impl<const STATES: usize, const INPUTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
-    for InputMatrixMutBuffer<STATES, INPUTS, T, MatrixDataOwned<STATES, INPUTS, TOTAL, T>>
+    for InputMatrixMutBuffer<STATES, INPUTS, T, MatrixDataArray<STATES, INPUTS, TOTAL, T>>
 {
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
             debug_assert_eq!(STATES * INPUTS, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<STATES, INPUTS, TOTAL, T>(value))
+        Self::new(MatrixData::new_array::<STATES, INPUTS, TOTAL, T>(value))
     }
 }
 

--- a/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
@@ -7,10 +7,38 @@ use minikalman_traits::matrix::{
 };
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Immutable buffer for the control matrix (`num_states` × `num_inputs`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = InputMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let data = [0.0; 4];
+/// let buffer = InputMatrixBuffer::<2, 2, f32, _>::from(data.as_ref());
+/// ```
 pub struct InputMatrixBuffer<const STATES: usize, const INPUTS: usize, T, M>(M, PhantomData<T>)
 where
     M: Matrix<STATES, INPUTS, T>;
 
+/// Mutable buffer for the control matrix (`num_states` × `num_inputs`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = InputMatrixMutBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = InputMatrixMutBuffer::<2, 2, f32, _>::from(data.as_mut());
+/// ```
 pub struct InputMatrixMutBuffer<const STATES: usize, const INPUTS: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<STATES, INPUTS, T>;

--- a/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
@@ -316,6 +316,16 @@ mod tests {
     }
 
     #[test]
+    fn test_from_mut() {
+        let mut data = [0.0_f32; 100];
+        let value: InputMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
+        assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
+    }
+
+    #[test]
     #[cfg(feature = "no_assert")]
     fn test_from_array_invalid_size() {
         let value: InputMatrixBuffer<5, 3, f32, _> = [0.0; 1].into();

--- a/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_matrix_buffer.rs
@@ -23,7 +23,7 @@ impl<const STATES: usize, const INPUTS: usize, const TOTAL: usize, T> From<[T; T
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * INPUTS, TOTAL);
+            debug_assert!(STATES * INPUTS <= TOTAL);
         }
         Self::new(MatrixData::new_array::<STATES, INPUTS, TOTAL, T>(value))
     }
@@ -35,7 +35,7 @@ impl<'a, const STATES: usize, const INPUTS: usize, T> From<&'a [T]>
     fn from(value: &'a [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * INPUTS, value.len());
+            debug_assert!(STATES * INPUTS <= value.len());
         }
         Self::new(MatrixData::new_ref::<STATES, INPUTS, T>(value))
     }
@@ -47,7 +47,7 @@ impl<'a, const STATES: usize, const INPUTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * INPUTS, value.len());
+            debug_assert!(STATES * INPUTS <= value.len());
         }
         Self::new(MatrixData::new_ref::<STATES, INPUTS, T>(value))
     }
@@ -59,7 +59,7 @@ impl<'a, const STATES: usize, const INPUTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * INPUTS, value.len());
+            debug_assert!(STATES * INPUTS <= value.len());
         }
         Self::new(MatrixData::new_mut::<STATES, INPUTS, T>(value))
     }
@@ -71,7 +71,7 @@ impl<const STATES: usize, const INPUTS: usize, const TOTAL: usize, T> From<[T; T
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * INPUTS, TOTAL);
+            debug_assert!(STATES * INPUTS <= TOTAL);
         }
         Self::new(MatrixData::new_array::<STATES, INPUTS, TOTAL, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/input_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_vector_buffer.rs
@@ -185,5 +185,6 @@ mod tests {
         let value: InputVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 }

--- a/crates/minikalman/src/buffer_types/input_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_vector_buffer.rs
@@ -5,6 +5,8 @@ use minikalman_traits::kalman::{InputVector, InputVectorMut};
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+// TODO: Add InputVectorMutBuffer
+
 pub struct InputVectorBuffer<const INPUTS: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<INPUTS, 1, T>;
@@ -23,6 +25,20 @@ impl<'a, const INPUTS: usize, T> From<&'a mut [T]>
     }
 }
 
+/// # Example
+/// Buffers can be trivially constructed from correctly-sized arrays:
+///
+/// ```
+/// # use minikalman::prelude::InputVectorBuffer;
+/// let _value: InputVectorBuffer<5, f32, _> = [0.0; 5].into();
+/// ```
+///
+/// Invalid buffer sizes fail to compile:
+///
+/// ```fail_compile
+/// # use minikalman::prelude::InputVectorBuffer;
+/// let _value: InputVectorBuffer<5, f32, _> = [0.0; 1].into();
+/// ```
 impl<const INPUTS: usize, T> From<[T; INPUTS]>
     for InputVectorBuffer<INPUTS, T, MatrixDataArray<INPUTS, 1, INPUTS, T>>
 {
@@ -156,12 +172,4 @@ mod tests {
         assert_eq!(value.len(), 5);
         assert!(value.is_valid());
     }
-
-    /* TODO: Turn into compile_fail doctest
-    #[test]
-    fn test_from_array_invalid_size() {
-        let value: InputVectorBuffer<5, f32, _> = [0.0; 1].into();
-        assert!(!value.is_valid());
-    }
-    */
 }

--- a/crates/minikalman/src/buffer_types/input_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_vector_buffer.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::{InputVector, InputVectorMut};
 
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct InputVectorBuffer<const INPUTS: usize, T, M>(M, PhantomData<T>)
@@ -24,10 +24,10 @@ impl<'a, const INPUTS: usize, T> From<&'a mut [T]>
 }
 
 impl<const INPUTS: usize, T> From<[T; INPUTS]>
-    for InputVectorBuffer<INPUTS, T, MatrixDataOwned<INPUTS, 1, INPUTS, T>>
+    for InputVectorBuffer<INPUTS, T, MatrixDataArray<INPUTS, 1, INPUTS, T>>
 {
     fn from(value: [T; INPUTS]) -> Self {
-        Self::new(MatrixData::new_owned::<INPUTS, 1, INPUTS, T>(value))
+        Self::new(MatrixData::new_array::<INPUTS, 1, INPUTS, T>(value))
     }
 }
 

--- a/crates/minikalman/src/buffer_types/input_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_vector_buffer.rs
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 5];
         let value: InputVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);

--- a/crates/minikalman/src/buffer_types/input_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_vector_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use minikalman_traits::kalman::{InputVector, InputVectorMut};
 
+use minikalman_traits::kalman::{InputVector, InputVectorMut};
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -136,4 +136,32 @@ where
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: InputVectorBuffer<5, f32, _> = [0.0; 5].into();
+        assert_eq!(value.len(), 5);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 5];
+        let value: InputVectorBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 5);
+        assert!(value.is_valid());
+    }
+
+    /* TODO: Turn into compile_fail doctest
+    #[test]
+    fn test_from_array_invalid_size() {
+        let value: InputVectorBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
+    }
+    */
 }

--- a/crates/minikalman/src/buffer_types/input_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_vector_buffer.rs
@@ -176,6 +176,7 @@ mod tests {
     fn test_from_array() {
         let value: InputVectorBuffer<5, f32, _> = [0.0; 5].into();
         assert_eq!(value.len(), 5);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -184,6 +185,7 @@ mod tests {
         let mut data = [0.0_f32; 5];
         let value: InputVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/input_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_vector_buffer.rs
@@ -19,7 +19,7 @@ impl<'a, const INPUTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(INPUTS, value.len());
+            debug_assert!(INPUTS <= value.len());
         }
         Self::new(MatrixData::new_mut::<INPUTS, 1, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/input_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_vector_buffer.rs
@@ -48,6 +48,11 @@ where
     pub const fn is_empty(&self) -> bool {
         INPUTS == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const INPUTS: usize, T, M> AsRef<[T]> for InputVectorBuffer<INPUTS, T, M>

--- a/crates/minikalman/src/buffer_types/input_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/input_vector_buffer.rs
@@ -7,6 +7,20 @@ use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 // TODO: Add InputVectorMutBuffer
 
+/// Mutable buffer for the control (input) vector (`num_inputs` × `1`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = InputVectorBuffer::new(MatrixData::new_array::<4, 1, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = InputVectorBuffer::<2, f32, _>::from(data.as_mut());
+/// ```
 pub struct InputVectorBuffer<const INPUTS: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<INPUTS, 1, T>;

--- a/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use minikalman_traits::kalman::KalmanGainMatrix;
 
+use minikalman_traits::kalman::KalmanGainMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -154,5 +154,32 @@ where
 
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: KalmanGainMatrixBuffer<5, 3, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 15);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: KalmanGainMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 15);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: KalmanGainMatrixBuffer<5, 3, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
     }
 }

--- a/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
@@ -5,6 +5,20 @@ use minikalman_traits::kalman::KalmanGainMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Mutable buffer for the Kalman Gain matrix (`num_states` × `num_measurements`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = KalmanGainMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = KalmanGainMatrixBuffer::<2, 2, f32, _>::from(data.as_mut());
+/// ```
 pub struct KalmanGainMatrixBuffer<const STATES: usize, const MEASUREMENTS: usize, T, M>(
     M,
     PhantomData<T>,

--- a/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
@@ -179,6 +179,7 @@ mod tests {
     fn test_from_array() {
         let value: KalmanGainMatrixBuffer<5, 3, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -187,6 +188,7 @@ mod tests {
         let mut data = [0.0_f32; 100];
         let value: KalmanGainMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
@@ -183,7 +183,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: KalmanGainMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);

--- a/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
@@ -188,6 +188,7 @@ mod tests {
         let value: KalmanGainMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
@@ -20,7 +20,7 @@ impl<'a, const STATES: usize, const MEASUREMENTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * MEASUREMENTS, value.len());
+            debug_assert!(STATES * MEASUREMENTS <= value.len());
         }
         Self::new(MatrixData::new_mut::<STATES, MEASUREMENTS, T>(value))
     }
@@ -37,7 +37,7 @@ impl<const STATES: usize, const MEASUREMENTS: usize, const TOTAL: usize, T> From
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * MEASUREMENTS, TOTAL);
+            debug_assert!(STATES * MEASUREMENTS <= TOTAL);
         }
         Self::new(MatrixData::new_array::<STATES, MEASUREMENTS, TOTAL, T>(
             value,

--- a/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
@@ -63,6 +63,11 @@ where
     pub const fn is_empty(&self) -> bool {
         STATES * MEASUREMENTS == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const STATES: usize, const MEASUREMENTS: usize, T, M> AsRef<[T]>

--- a/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/kalman_gain_matrix_buffer.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::KalmanGainMatrix;
 
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct KalmanGainMatrixBuffer<const STATES: usize, const MEASUREMENTS: usize, T, M>(
@@ -31,7 +31,7 @@ impl<const STATES: usize, const MEASUREMENTS: usize, const TOTAL: usize, T> From
         STATES,
         MEASUREMENTS,
         T,
-        MatrixDataOwned<STATES, MEASUREMENTS, TOTAL, T>,
+        MatrixDataArray<STATES, MEASUREMENTS, TOTAL, T>,
     >
 {
     fn from(value: [T; TOTAL]) -> Self {
@@ -39,7 +39,7 @@ impl<const STATES: usize, const MEASUREMENTS: usize, const TOTAL: usize, T> From
         {
             debug_assert_eq!(STATES * MEASUREMENTS, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<STATES, MEASUREMENTS, TOTAL, T>(
+        Self::new(MatrixData::new_array::<STATES, MEASUREMENTS, TOTAL, T>(
             value,
         ))
     }

--- a/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
@@ -363,6 +363,16 @@ mod tests {
     }
 
     #[test]
+    fn test_from_mut() {
+        let mut data = [0.0_f32; 100];
+        let value: MeasurementObservationMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
+        assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
+    }
+
+    #[test]
     #[cfg(feature = "no_assert")]
     fn test_from_array_invalid_size() {
         let value: MeasurementObservationMatrixBuffer<5, 3, f32, _> = [0.0; 1].into();

--- a/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
@@ -7,6 +7,20 @@ use minikalman_traits::matrix::{
 };
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Immutable buffer for the observation matrix (`num_inputs` × `num_states`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = MeasurementObservationMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let data = [0.0; 4];
+/// let buffer = MeasurementObservationMatrixBuffer::<2, 2, f32, _>::from(data.as_ref());
+/// ```
 pub struct MeasurementObservationMatrixBuffer<const MEASUREMENTS: usize, const STATES: usize, T, M>(
     M,
     PhantomData<T>,
@@ -14,6 +28,20 @@ pub struct MeasurementObservationMatrixBuffer<const MEASUREMENTS: usize, const S
 where
     M: Matrix<MEASUREMENTS, STATES, T>;
 
+/// Mmutable buffer for the observation matrix (`num_inputs` × `num_states`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = MeasurementObservationMatrixMutBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = MeasurementObservationMatrixMutBuffer::<2, 2, f32, _>::from(data.as_mut());
+/// ```
 pub struct MeasurementObservationMatrixMutBuffer<
     const MEASUREMENTS: usize,
     const STATES: usize,

--- a/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
@@ -353,8 +353,8 @@ mod tests {
 
     #[test]
     fn test_from_ref() {
-        let mut data = [0.0_f32; 100];
-        let value: MeasurementObservationMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
+        let data = [0.0_f32; 100];
+        let value: MeasurementObservationMatrixBuffer<5, 3, f32, _> = data.as_ref().into();
         assert_eq!(value.len(), 15);
         assert!(value.is_valid());
     }
@@ -374,7 +374,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mut_from_ref() {
+    fn test_mut_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: MeasurementObservationMatrixMutBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);

--- a/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
@@ -348,6 +348,7 @@ mod tests {
     fn test_from_array() {
         let value: MeasurementObservationMatrixBuffer<5, 3, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -356,6 +357,7 @@ mod tests {
         let data = [0.0_f32; 100];
         let value: MeasurementObservationMatrixBuffer<5, 3, f32, _> = data.as_ref().into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }
@@ -371,6 +373,7 @@ mod tests {
     fn test_mut_from_array() {
         let value: MeasurementObservationMatrixMutBuffer<5, 3, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -379,6 +382,7 @@ mod tests {
         let mut data = [0.0_f32; 100];
         let value: MeasurementObservationMatrixMutBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
@@ -3,7 +3,7 @@ use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::{MeasurementObservationMatrix, MeasurementObservationMatrixMut};
 
 use minikalman_traits::matrix::{
-    IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned, MatrixDataRef,
+    IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut, MatrixDataRef,
 };
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -81,7 +81,7 @@ impl<const MEASUREMENTS: usize, const STATES: usize, const TOTAL: usize, T> From
         MEASUREMENTS,
         STATES,
         T,
-        MatrixDataOwned<MEASUREMENTS, STATES, TOTAL, T>,
+        MatrixDataArray<MEASUREMENTS, STATES, TOTAL, T>,
     >
 {
     fn from(value: [T; TOTAL]) -> Self {
@@ -89,7 +89,7 @@ impl<const MEASUREMENTS: usize, const STATES: usize, const TOTAL: usize, T> From
         {
             debug_assert_eq!(MEASUREMENTS * STATES, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<MEASUREMENTS, STATES, TOTAL, T>(
+        Self::new(MatrixData::new_array::<MEASUREMENTS, STATES, TOTAL, T>(
             value,
         ))
     }

--- a/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
@@ -36,7 +36,7 @@ impl<const MEASUREMENTS: usize, const STATES: usize, const TOTAL: usize, T> From
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * STATES, TOTAL);
+            debug_assert!(MEASUREMENTS * STATES <= TOTAL);
         }
         Self::new(MatrixData::new_array::<MEASUREMENTS, STATES, TOTAL, T>(
             value,
@@ -55,7 +55,7 @@ impl<'a, const MEASUREMENTS: usize, const STATES: usize, T> From<&'a [T]>
     fn from(value: &'a [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * STATES, value.len());
+            debug_assert!(MEASUREMENTS * STATES <= value.len());
         }
         Self::new(MatrixData::new_ref::<MEASUREMENTS, STATES, T>(value))
     }
@@ -72,7 +72,7 @@ impl<'a, const MEASUREMENTS: usize, const STATES: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * STATES, value.len());
+            debug_assert!(MEASUREMENTS * STATES <= value.len());
         }
         Self::new(MatrixData::new_ref::<MEASUREMENTS, STATES, T>(value))
     }
@@ -89,7 +89,7 @@ impl<'a, const MEASUREMENTS: usize, const STATES: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * STATES, value.len());
+            debug_assert!(MEASUREMENTS * STATES <= value.len());
         }
         Self::new(MatrixData::new_mut::<MEASUREMENTS, STATES, T>(value))
     }
@@ -106,7 +106,7 @@ impl<const MEASUREMENTS: usize, const STATES: usize, const TOTAL: usize, T> From
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * STATES, TOTAL);
+            debug_assert!(MEASUREMENTS * STATES <= TOTAL);
         }
         Self::new(MatrixData::new_array::<MEASUREMENTS, STATES, TOTAL, T>(
             value,

--- a/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use minikalman_traits::kalman::{MeasurementObservationMatrix, MeasurementObservationMatrixMut};
 
+use minikalman_traits::kalman::{MeasurementObservationMatrix, MeasurementObservationMatrixMut};
 use minikalman_traits::matrix::{
     IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut, MatrixDataRef,
 };
@@ -24,6 +24,25 @@ where
     M: MatrixMut<MEASUREMENTS, STATES, T>;
 
 // -----------------------------------------------------------
+
+impl<const MEASUREMENTS: usize, const STATES: usize, const TOTAL: usize, T> From<[T; TOTAL]>
+    for MeasurementObservationMatrixBuffer<
+        MEASUREMENTS,
+        STATES,
+        T,
+        MatrixDataArray<MEASUREMENTS, STATES, TOTAL, T>,
+    >
+{
+    fn from(value: [T; TOTAL]) -> Self {
+        #[cfg(not(feature = "no_assert"))]
+        {
+            debug_assert_eq!(MEASUREMENTS * STATES, TOTAL);
+        }
+        Self::new(MatrixData::new_array::<MEASUREMENTS, STATES, TOTAL, T>(
+            value,
+        ))
+    }
+}
 
 impl<'a, const MEASUREMENTS: usize, const STATES: usize, T> From<&'a [T]>
     for MeasurementObservationMatrixBuffer<
@@ -166,6 +185,11 @@ where
     pub const fn is_empty(&self) -> bool {
         MEASUREMENTS * STATES == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const MEASUREMENTS: usize, const STATES: usize, T, M> AsRef<[T]>
@@ -285,5 +309,54 @@ where
 
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: MeasurementObservationMatrixBuffer<5, 3, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 15);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: MeasurementObservationMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 15);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: MeasurementObservationMatrixBuffer<5, 3, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
+    }
+
+    #[test]
+    fn test_mut_from_array() {
+        let value: MeasurementObservationMatrixMutBuffer<5, 3, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 15);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_mut_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: MeasurementObservationMatrixMutBuffer<5, 3, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 15);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_mut_from_array_invalid_size() {
+        let value: MeasurementObservationMatrixMutBuffer<5, 3, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
     }
 }

--- a/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
@@ -357,6 +357,7 @@ mod tests {
         let value: MeasurementObservationMatrixBuffer<5, 3, f32, _> = data.as_ref().into();
         assert_eq!(value.len(), 15);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]
@@ -379,6 +380,7 @@ mod tests {
         let value: MeasurementObservationMatrixMutBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_observation_matrix_buffer.rs
@@ -113,6 +113,11 @@ where
     pub const fn is_empty(&self) -> bool {
         MEASUREMENTS * STATES == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const MEASUREMENTS: usize, const STATES: usize, T, M> AsRef<[T]>

--- a/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
@@ -180,6 +180,7 @@ mod tests {
     fn test_from_array() {
         let value: MeasurementProcessNoiseCovarianceMatrixBuffer<5, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -188,6 +189,7 @@ mod tests {
         let mut data = [0.0_f32; 100];
         let value: MeasurementProcessNoiseCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
@@ -184,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: MeasurementProcessNoiseCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);

--- a/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
@@ -5,6 +5,20 @@ use minikalman_traits::kalman::MeasurementProcessNoiseCovarianceMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Mutable buffer for the observation covariance matrix (`num_measurements` × `num_measurements`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = MeasurementProcessNoiseCovarianceMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = MeasurementProcessNoiseCovarianceMatrixBuffer::<2, f32, _>::from(data.as_mut());
+/// ```
 pub struct MeasurementProcessNoiseCovarianceMatrixBuffer<const MEASUREMENT: usize, T, M>(
     M,
     PhantomData<T>,

--- a/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
@@ -189,6 +189,7 @@ mod tests {
         let value: MeasurementProcessNoiseCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
@@ -63,6 +63,11 @@ where
     pub const fn is_empty(&self) -> bool {
         MEASUREMENT * MEASUREMENT == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const MEASUREMENT: usize, T, M> AsRef<[T]>

--- a/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::MeasurementProcessNoiseCovarianceMatrix;
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct MeasurementProcessNoiseCovarianceMatrixBuffer<const MEASUREMENT: usize, T, M>(
@@ -33,7 +33,7 @@ impl<const MEASUREMENTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     for MeasurementProcessNoiseCovarianceMatrixBuffer<
         MEASUREMENTS,
         T,
-        MatrixDataOwned<MEASUREMENTS, MEASUREMENTS, TOTAL, T>,
+        MatrixDataArray<MEASUREMENTS, MEASUREMENTS, TOTAL, T>,
     >
 {
     fn from(value: [T; TOTAL]) -> Self {
@@ -41,7 +41,7 @@ impl<const MEASUREMENTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
         {
             debug_assert_eq!(MEASUREMENTS * MEASUREMENTS, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<MEASUREMENTS, MEASUREMENTS, TOTAL, T>(value))
+        Self::new(MatrixData::new_array::<MEASUREMENTS, MEASUREMENTS, TOTAL, T>(value))
     }
 }
 

--- a/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
@@ -24,7 +24,7 @@ impl<'a, const MEASUREMENTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * MEASUREMENTS, value.len());
+            debug_assert!(MEASUREMENTS * MEASUREMENTS <= value.len());
         }
         Self::new(MatrixData::new_mut::<MEASUREMENTS, MEASUREMENTS, T>(value))
     }
@@ -40,7 +40,7 @@ impl<const MEASUREMENTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * MEASUREMENTS, TOTAL);
+            debug_assert!(MEASUREMENTS * MEASUREMENTS <= TOTAL);
         }
         Self::new(MatrixData::new_array::<MEASUREMENTS, MEASUREMENTS, TOTAL, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_process_noise_covariance_matrix_buffer.rs
@@ -1,5 +1,6 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
+
 use minikalman_traits::kalman::MeasurementProcessNoiseCovarianceMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
@@ -154,5 +155,32 @@ where
 
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: MeasurementProcessNoiseCovarianceMatrixBuffer<5, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: MeasurementProcessNoiseCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: MeasurementProcessNoiseCovarianceMatrixBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
     }
 }

--- a/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
@@ -5,6 +5,8 @@ use minikalman_traits::kalman::{MeasurementVector, MeasurementVectorMut};
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+// TODO: Add MeasurementVectorMutBuffer
+
 pub struct MeasurementVectorBuffer<const MEASUREMENTS: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<MEASUREMENTS, 1, T>;
@@ -23,6 +25,20 @@ impl<'a, const MEASUREMENTS: usize, T> From<&'a mut [T]>
     }
 }
 
+/// # Example
+/// Buffers can be trivially constructed from correctly-sized arrays:
+///
+/// ```
+/// # use minikalman::prelude::MeasurementVectorBuffer;
+/// let _value: MeasurementVectorBuffer<5, f32, _> = [0.0; 5].into();
+/// ```
+///
+/// Invalid buffer sizes fail to compile:
+///
+/// ```fail_compile
+/// # use minikalman::prelude::MeasurementVectorBuffer;
+/// let _value: MeasurementVectorBuffer<5, f32, _> = [0.0; 1].into();
+/// ```
 impl<const MEASUREMENTS: usize, T> From<[T; MEASUREMENTS]>
     for MeasurementVectorBuffer<MEASUREMENTS, T, MatrixDataArray<MEASUREMENTS, 1, MEASUREMENTS, T>>
 {
@@ -165,12 +181,4 @@ mod tests {
         assert_eq!(value.len(), 5);
         assert!(value.is_valid());
     }
-
-    /* TODO: Turn into compile_fail doctest
-    #[test]
-    fn test_from_array_invalid_size() {
-        let value: MeasurementVectorBuffer<5, f32, _> = [0.0; 1].into();
-        assert!(!value.is_valid());
-    }
-    */
 }

--- a/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
@@ -7,6 +7,20 @@ use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 // TODO: Add MeasurementVectorMutBuffer
 
+/// Mutable buffer for the observation (measurement) vector (`num_measurements` × `1`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = MeasurementVectorBuffer::new(MatrixData::new_array::<4, 1, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = MeasurementVectorBuffer::<2, f32, _>::from(data.as_mut());
+/// ```
 pub struct MeasurementVectorBuffer<const MEASUREMENTS: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<MEASUREMENTS, 1, T>;

--- a/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
@@ -185,6 +185,7 @@ mod tests {
     fn test_from_array() {
         let value: MeasurementVectorBuffer<5, f32, _> = [0.0; 5].into();
         assert_eq!(value.len(), 5);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -193,6 +194,7 @@ mod tests {
         let mut data = [0.0_f32; 5];
         let value: MeasurementVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
@@ -19,7 +19,7 @@ impl<'a, const MEASUREMENTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS, value.len());
+            debug_assert!(MEASUREMENTS <= value.len());
         }
         Self::new(MatrixData::new_mut::<MEASUREMENTS, 1, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::{MeasurementVector, MeasurementVectorMut};
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct MeasurementVectorBuffer<const MEASUREMENTS: usize, T, M>(M, PhantomData<T>)
@@ -23,10 +23,10 @@ impl<'a, const MEASUREMENTS: usize, T> From<&'a mut [T]>
 }
 
 impl<const MEASUREMENTS: usize, T> From<[T; MEASUREMENTS]>
-    for MeasurementVectorBuffer<MEASUREMENTS, T, MatrixDataOwned<MEASUREMENTS, 1, MEASUREMENTS, T>>
+    for MeasurementVectorBuffer<MEASUREMENTS, T, MatrixDataArray<MEASUREMENTS, 1, MEASUREMENTS, T>>
 {
     fn from(value: [T; MEASUREMENTS]) -> Self {
-        Self::new(MatrixData::new_owned::<MEASUREMENTS, 1, MEASUREMENTS, T>(
+        Self::new(MatrixData::new_array::<MEASUREMENTS, 1, MEASUREMENTS, T>(
             value,
         ))
     }

--- a/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
@@ -194,5 +194,6 @@ mod tests {
         let value: MeasurementVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 }

--- a/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
@@ -49,6 +49,11 @@ where
     pub const fn is_empty(&self) -> bool {
         MEASUREMENTS == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const MEASUREMENTS: usize, T, M> AsRef<[T]> for MeasurementVectorBuffer<MEASUREMENTS, T, M>

--- a/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
@@ -1,5 +1,6 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
+
 use minikalman_traits::kalman::{MeasurementVector, MeasurementVectorMut};
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
@@ -144,4 +145,32 @@ where
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: MeasurementVectorBuffer<5, f32, _> = [0.0; 5].into();
+        assert_eq!(value.len(), 5);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 5];
+        let value: MeasurementVectorBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 5);
+        assert!(value.is_valid());
+    }
+
+    /* TODO: Turn into compile_fail doctest
+    #[test]
+    fn test_from_array_invalid_size() {
+        let value: MeasurementVectorBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
+    }
+    */
 }

--- a/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/measurement_vector_buffer.rs
@@ -189,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 5];
         let value: MeasurementVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);

--- a/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
@@ -5,6 +5,20 @@ use minikalman_traits::kalman::StatePredictionVector;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Mutable buffer for the temporary state prediction vector (`num_states` × `1`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = TemporaryStatePredictionVectorBuffer::new(MatrixData::new_array::<4, 1, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = TemporaryStatePredictionVectorBuffer::<2, f32, _>::from(data.as_mut());
+/// ```
 pub struct TemporaryStatePredictionVectorBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<STATES, 1, T>;

--- a/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use minikalman_traits::kalman::StatePredictionVector;
 
+use minikalman_traits::kalman::StatePredictionVector;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -136,4 +136,32 @@ where
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: TemporaryStatePredictionVectorBuffer<5, f32, _> = [0.0; 5].into();
+        assert_eq!(value.len(), 5);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 5];
+        let value: TemporaryStatePredictionVectorBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 5);
+        assert!(value.is_valid());
+    }
+
+    /* TODO: Turn into compile_fail doctest
+    #[test]
+    fn test_from_array_invalid_size() {
+        let value: TemporaryStatePredictionVectorBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
+    }
+    */
 }

--- a/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
@@ -17,7 +17,7 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES, value.len());
+            debug_assert!(STATES <= value.len());
         }
         Self::new(MatrixData::new_mut::<STATES, 1, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
@@ -174,6 +174,7 @@ mod tests {
     fn test_from_array() {
         let value: TemporaryStatePredictionVectorBuffer<5, f32, _> = [0.0; 5].into();
         assert_eq!(value.len(), 5);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -182,6 +183,7 @@ mod tests {
         let mut data = [0.0_f32; 5];
         let value: TemporaryStatePredictionVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
@@ -178,7 +178,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 5];
         let value: TemporaryStatePredictionVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);

--- a/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
@@ -183,5 +183,6 @@ mod tests {
         let value: TemporaryStatePredictionVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 }

--- a/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
@@ -48,6 +48,11 @@ where
     pub const fn is_empty(&self) -> bool {
         STATES == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const STATES: usize, T, M> AsRef<[T]> for TemporaryStatePredictionVectorBuffer<STATES, T, M>

--- a/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
@@ -23,6 +23,20 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
     }
 }
 
+/// # Example
+/// Buffers can be trivially constructed from correctly-sized arrays:
+///
+/// ```
+/// # use minikalman::prelude::TemporaryStatePredictionVectorBuffer;
+/// let _value: TemporaryStatePredictionVectorBuffer<5, f32, _> = [0.0; 5].into();
+/// ```
+///
+/// Invalid buffer sizes fail to compile:
+///
+/// ```fail_compile
+/// # use minikalman::prelude::TemporaryStatePredictionVectorBuffer;
+/// let _value: TemporaryStatePredictionVectorBuffer<5, f32, _> = [0.0; 1].into();
+/// ```
 impl<const STATES: usize, T> From<[T; STATES]>
     for TemporaryStatePredictionVectorBuffer<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>
 {
@@ -156,12 +170,4 @@ mod tests {
         assert_eq!(value.len(), 5);
         assert!(value.is_valid());
     }
-
-    /* TODO: Turn into compile_fail doctest
-    #[test]
-    fn test_from_array_invalid_size() {
-        let value: TemporaryStatePredictionVectorBuffer<5, f32, _> = [0.0; 1].into();
-        assert!(!value.is_valid());
-    }
-    */
 }

--- a/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_prediction_vector_buffer.rs
@@ -2,17 +2,17 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::StatePredictionVector;
 
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
-pub struct StatePredictionVectorBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
+pub struct TemporaryStatePredictionVectorBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<STATES, 1, T>;
 
 // -----------------------------------------------------------
 
 impl<'a, const STATES: usize, T> From<&'a mut [T]>
-    for StatePredictionVectorBuffer<STATES, T, MatrixDataMut<'a, STATES, 1, T>>
+    for TemporaryStatePredictionVectorBuffer<STATES, T, MatrixDataMut<'a, STATES, 1, T>>
 {
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
@@ -24,16 +24,16 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
 }
 
 impl<const STATES: usize, T> From<[T; STATES]>
-    for StatePredictionVectorBuffer<STATES, T, MatrixDataOwned<STATES, 1, STATES, T>>
+    for TemporaryStatePredictionVectorBuffer<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>
 {
     fn from(value: [T; STATES]) -> Self {
-        Self::new(MatrixData::new_owned::<STATES, 1, STATES, T>(value))
+        Self::new(MatrixData::new_array::<STATES, 1, STATES, T>(value))
     }
 }
 
 // -----------------------------------------------------------
 
-impl<const STATES: usize, T, M> StatePredictionVectorBuffer<STATES, T, M>
+impl<const STATES: usize, T, M> TemporaryStatePredictionVectorBuffer<STATES, T, M>
 where
     M: MatrixMut<STATES, 1, T>,
 {
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl<const STATES: usize, T, M> AsRef<[T]> for StatePredictionVectorBuffer<STATES, T, M>
+impl<const STATES: usize, T, M> AsRef<[T]> for TemporaryStatePredictionVectorBuffer<STATES, T, M>
 where
     M: MatrixMut<STATES, 1, T>,
 {
@@ -59,7 +59,7 @@ where
     }
 }
 
-impl<const STATES: usize, T, M> AsMut<[T]> for StatePredictionVectorBuffer<STATES, T, M>
+impl<const STATES: usize, T, M> AsMut<[T]> for TemporaryStatePredictionVectorBuffer<STATES, T, M>
 where
     M: MatrixMut<STATES, 1, T>,
 {
@@ -68,20 +68,22 @@ where
     }
 }
 
-impl<const STATES: usize, T, M> Matrix<STATES, 1, T> for StatePredictionVectorBuffer<STATES, T, M> where
-    M: MatrixMut<STATES, 1, T>
+impl<const STATES: usize, T, M> Matrix<STATES, 1, T>
+    for TemporaryStatePredictionVectorBuffer<STATES, T, M>
+where
+    M: MatrixMut<STATES, 1, T>,
 {
 }
 
 impl<const STATES: usize, T, M> MatrixMut<STATES, 1, T>
-    for StatePredictionVectorBuffer<STATES, T, M>
+    for TemporaryStatePredictionVectorBuffer<STATES, T, M>
 where
     M: MatrixMut<STATES, 1, T>,
 {
 }
 
 impl<const STATES: usize, T, M> StatePredictionVector<STATES, T>
-    for StatePredictionVectorBuffer<STATES, T, M>
+    for TemporaryStatePredictionVectorBuffer<STATES, T, M>
 where
     M: MatrixMut<STATES, 1, T>,
 {
@@ -97,7 +99,7 @@ where
     }
 }
 
-impl<const STATES: usize, T, M> Index<usize> for StatePredictionVectorBuffer<STATES, T, M>
+impl<const STATES: usize, T, M> Index<usize> for TemporaryStatePredictionVectorBuffer<STATES, T, M>
 where
     M: MatrixMut<STATES, 1, T>,
 {
@@ -108,7 +110,8 @@ where
     }
 }
 
-impl<const STATES: usize, T, M> IndexMut<usize> for StatePredictionVectorBuffer<STATES, T, M>
+impl<const STATES: usize, T, M> IndexMut<usize>
+    for TemporaryStatePredictionVectorBuffer<STATES, T, M>
 where
     M: MatrixMut<STATES, 1, T>,
 {
@@ -119,7 +122,7 @@ where
 
 // -----------------------------------------------------------
 
-impl<const STATES: usize, T, M> IntoInnerData for StatePredictionVectorBuffer<STATES, T, M>
+impl<const STATES: usize, T, M> IntoInnerData for TemporaryStatePredictionVectorBuffer<STATES, T, M>
 where
     M: MatrixMut<STATES, 1, T> + IntoInnerData,
 {

--- a/crates/minikalman/src/buffer_types/state_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_vector_buffer.rs
@@ -1,5 +1,6 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
+
 use minikalman_traits::kalman::{StateVector, StateVectorMut};
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
@@ -135,4 +136,32 @@ where
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: StateVectorBuffer<5, f32, _> = [0.0; 5].into();
+        assert_eq!(value.len(), 5);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 5];
+        let value: StateVectorBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 5);
+        assert!(value.is_valid());
+    }
+
+    /* TODO: Turn into compile_fail doctest
+    #[test]
+    fn test_from_array_invalid_size() {
+        let value: StateVectorBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
+    }
+    */
 }

--- a/crates/minikalman/src/buffer_types/state_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_vector_buffer.rs
@@ -47,6 +47,11 @@ where
     pub const fn is_empty(&self) -> bool {
         STATES == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const STATES: usize, T, M> AsRef<[T]> for StateVectorBuffer<STATES, T, M>

--- a/crates/minikalman/src/buffer_types/state_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_vector_buffer.rs
@@ -17,7 +17,7 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES, value.len());
+            debug_assert!(STATES <= value.len());
         }
         Self::new(MatrixData::new_mut::<STATES, 1, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/state_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_vector_buffer.rs
@@ -5,6 +5,20 @@ use minikalman_traits::kalman::{StateVector, StateVectorMut};
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Mutable buffer for the state vector (`num_states` × `1`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = StateVectorBuffer::new(MatrixData::new_array::<4, 1, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = StateVectorBuffer::<2, f32, _>::from(data.as_mut());
+/// ```
 pub struct StateVectorBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<STATES, 1, T>;

--- a/crates/minikalman/src/buffer_types/state_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_vector_buffer.rs
@@ -23,6 +23,20 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
     }
 }
 
+/// # Example
+/// Buffers can be trivially constructed from correctly-sized arrays:
+///
+/// ```
+/// # use minikalman::prelude::StateVectorBuffer;
+/// let _value: StateVectorBuffer<5, f32, _> = [0.0; 5].into();
+/// ```
+///
+/// Invalid buffer sizes fail to compile:
+///
+/// ```fail_compile
+/// # use minikalman::prelude::StateVectorBuffer;
+/// let _value: StateVectorBuffer<5, f32, _> = [0.0; 1].into();
+/// ```
 impl<const STATES: usize, T> From<[T; STATES]>
     for StateVectorBuffer<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>
 {
@@ -156,12 +170,4 @@ mod tests {
         assert_eq!(value.len(), 5);
         assert!(value.is_valid());
     }
-
-    /* TODO: Turn into compile_fail doctest
-    #[test]
-    fn test_from_array_invalid_size() {
-        let value: StateVectorBuffer<5, f32, _> = [0.0; 1].into();
-        assert!(!value.is_valid());
-    }
-    */
 }

--- a/crates/minikalman/src/buffer_types/state_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_vector_buffer.rs
@@ -183,5 +183,6 @@ mod tests {
         let value: StateVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 }

--- a/crates/minikalman/src/buffer_types/state_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_vector_buffer.rs
@@ -178,7 +178,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 5];
         let value: StateVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);

--- a/crates/minikalman/src/buffer_types/state_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_vector_buffer.rs
@@ -174,6 +174,7 @@ mod tests {
     fn test_from_array() {
         let value: StateVectorBuffer<5, f32, _> = [0.0; 5].into();
         assert_eq!(value.len(), 5);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -182,6 +183,7 @@ mod tests {
         let mut data = [0.0_f32; 5];
         let value: StateVectorBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 5);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/state_vector_buffer.rs
+++ b/crates/minikalman/src/buffer_types/state_vector_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use minikalman_traits::kalman::StateVector;
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::kalman::{StateVector, StateVectorMut};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct StateVectorBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
@@ -23,10 +23,10 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
 }
 
 impl<const STATES: usize, T> From<[T; STATES]>
-    for StateVectorBuffer<STATES, T, MatrixDataOwned<STATES, 1, STATES, T>>
+    for StateVectorBuffer<STATES, T, MatrixDataArray<STATES, 1, STATES, T>>
 {
     fn from(value: [T; STATES]) -> Self {
-        Self::new(MatrixData::new_owned::<STATES, 1, STATES, T>(value))
+        Self::new(MatrixData::new_array::<STATES, 1, STATES, T>(value))
     }
 }
 
@@ -82,11 +82,17 @@ where
     M: MatrixMut<STATES, 1, T>,
 {
     type Target = M;
-    type TargetMut = M;
 
     fn as_matrix(&self) -> &Self::Target {
         &self.0
     }
+}
+
+impl<const STATES: usize, T, M> StateVectorMut<STATES, T> for StateVectorBuffer<STATES, T, M>
+where
+    M: MatrixMut<STATES, 1, T>,
+{
+    type TargetMut = M;
 
     fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
         &mut self.0

--- a/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
@@ -52,6 +52,11 @@ where
     pub const fn is_empty(&self) -> bool {
         STATES * STATES == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const STATES: usize, T, M> AsRef<[T]> for SystemCovarianceMatrixBuffer<STATES, T, M>

--- a/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
@@ -163,6 +163,7 @@ mod tests {
     fn test_from_array() {
         let value: SystemCovarianceMatrixBuffer<5, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -171,6 +172,7 @@ mod tests {
         let mut data = [0.0_f32; 100];
         let value: SystemCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
@@ -5,6 +5,20 @@ use minikalman_traits::kalman::SystemCovarianceMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Mutable buffer for the system covariance matrix (`num_states` × `num_states`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = SystemCovarianceMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = SystemCovarianceMatrixBuffer::<2, f32, _>::from(data.as_mut());
+/// ```
 pub struct SystemCovarianceMatrixBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<STATES, STATES, T>;

--- a/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
@@ -172,6 +172,7 @@ mod tests {
         let value: SystemCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
@@ -17,7 +17,7 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * STATES, value.len());
+            debug_assert!(STATES * STATES <= value.len());
         }
         Self::new(MatrixData::new_mut::<STATES, STATES, T>(value))
     }
@@ -29,7 +29,7 @@ impl<const STATES: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * STATES, TOTAL);
+            debug_assert!(STATES * STATES <= TOTAL);
         }
         Self::new(MatrixData::new_array::<STATES, STATES, TOTAL, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
@@ -167,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: SystemCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);

--- a/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::SystemCovarianceMatrix;
 
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct SystemCovarianceMatrixBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
@@ -24,14 +24,14 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
 }
 
 impl<const STATES: usize, const TOTAL: usize, T> From<[T; TOTAL]>
-    for SystemCovarianceMatrixBuffer<STATES, T, MatrixDataOwned<STATES, STATES, TOTAL, T>>
+    for SystemCovarianceMatrixBuffer<STATES, T, MatrixDataArray<STATES, STATES, TOTAL, T>>
 {
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
             debug_assert_eq!(STATES * STATES, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<STATES, STATES, TOTAL, T>(value))
+        Self::new(MatrixData::new_array::<STATES, STATES, TOTAL, T>(value))
     }
 }
 

--- a/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_covariance_matrix_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use minikalman_traits::kalman::SystemCovarianceMatrix;
 
+use minikalman_traits::kalman::SystemCovarianceMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -138,5 +138,32 @@ where
 
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: SystemCovarianceMatrixBuffer<5, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: SystemCovarianceMatrixBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: SystemCovarianceMatrixBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
     }
 }

--- a/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
@@ -317,7 +317,7 @@ mod tests {
 
     #[test]
     fn test_mut_from_array() {
-        let value: SystemMatrixBuffer<5, f32, _> = [0.0; 100].into();
+        let value: SystemMatrixMutBuffer<5, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 25);
         assert!(!value.is_empty());
         assert!(value.is_valid());
@@ -338,5 +338,12 @@ mod tests {
     fn test_mut_from_array_invalid_size() {
         let value: SystemMatrixMutBuffer<5, f32, _> = [0.0; 1].into();
         assert!(!value.is_valid());
+    }
+
+    #[test]
+    fn array_into_inner() {
+        let value: SystemMatrixBuffer<2, f32, _> = [0.0, 1.0, 3.0, 4.0].into();
+        let data = value.into_inner();
+        assert_eq!(data, [0.0, 1.0, 3.0, 4.0]);
     }
 }

--- a/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
@@ -299,6 +299,16 @@ mod tests {
     }
 
     #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: SystemMatrixBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
+        assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
+    }
+
+    #[test]
     #[cfg(feature = "no_assert")]
     fn test_from_array_invalid_size() {
         let value: SystemMatrixBuffer<5, f32, _> = [0.0; 1].into();

--- a/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
@@ -3,7 +3,7 @@ use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::{SystemMatrix, SystemMatrixMut};
 
 use minikalman_traits::matrix::{
-    IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned, MatrixDataRef,
+    IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut, MatrixDataRef,
 };
 
 use minikalman_traits::matrix::{Matrix, MatrixMut};
@@ -55,14 +55,14 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
 }
 
 impl<const STATES: usize, const TOTAL: usize, T> From<[T; TOTAL]>
-    for SystemMatrixMutBuffer<STATES, T, MatrixDataOwned<STATES, STATES, TOTAL, T>>
+    for SystemMatrixMutBuffer<STATES, T, MatrixDataArray<STATES, STATES, TOTAL, T>>
 {
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
             debug_assert_eq!(STATES * STATES, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<STATES, STATES, TOTAL, T>(value))
+        Self::new(MatrixData::new_array::<STATES, STATES, TOTAL, T>(value))
     }
 }
 

--- a/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
@@ -284,6 +284,7 @@ mod tests {
     fn test_from_array() {
         let value: SystemMatrixBuffer<5, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -292,6 +293,7 @@ mod tests {
         let data = [0.0_f32; 100];
         let value: SystemMatrixBuffer<5, f32, _> = data.as_ref().into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }
@@ -307,6 +309,7 @@ mod tests {
     fn test_mut_from_array() {
         let value: SystemMatrixBuffer<5, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -315,6 +318,7 @@ mod tests {
         let mut data = [0.0_f32; 100];
         let value: SystemMatrixMutBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
@@ -23,7 +23,7 @@ impl<const STATES: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * STATES, TOTAL);
+            debug_assert!(STATES * STATES <= TOTAL);
         }
         Self::new(MatrixData::new_array::<STATES, STATES, TOTAL, T>(value))
     }
@@ -35,7 +35,7 @@ impl<'a, const STATES: usize, T> From<&'a [T]>
     fn from(value: &'a [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * STATES, value.len());
+            debug_assert!(STATES * STATES <= value.len());
         }
         Self::new(MatrixData::new_ref::<STATES, STATES, T>(value))
     }
@@ -47,7 +47,7 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * STATES, value.len());
+            debug_assert!(STATES * STATES <= value.len());
         }
         Self::new(MatrixData::new_ref::<STATES, STATES, T>(value))
     }
@@ -59,7 +59,7 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * STATES, value.len());
+            debug_assert!(STATES * STATES <= value.len());
         }
         Self::new(MatrixData::new_mut::<STATES, STATES, T>(value))
     }
@@ -71,7 +71,7 @@ impl<const STATES: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * STATES, TOTAL);
+            debug_assert!(STATES * STATES <= TOTAL);
         }
         Self::new(MatrixData::new_array::<STATES, STATES, TOTAL, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
@@ -7,10 +7,38 @@ use minikalman_traits::matrix::{
 };
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Immutable buffer for the system matrix (`num_states` × `num_states`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = SystemMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let data = [0.0; 4];
+/// let buffer = SystemMatrixBuffer::<2, f32, _>::from(data.as_ref());
+/// ```
 pub struct SystemMatrixBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
 where
     M: Matrix<STATES, STATES, T>;
 
+/// Mutable buffer for the system matrix (`num_states` × `num_states`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = SystemMatrixMutBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = SystemMatrixMutBuffer::<2, f32, _>::from(data.as_mut());
+/// ```
 pub struct SystemMatrixMutBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<STATES, STATES, T>;

--- a/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
@@ -293,6 +293,7 @@ mod tests {
         let value: SystemMatrixBuffer<5, f32, _> = data.as_ref().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]
@@ -315,6 +316,7 @@ mod tests {
         let value: SystemMatrixMutBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
@@ -299,7 +299,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: SystemMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);

--- a/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
@@ -289,8 +289,8 @@ mod tests {
 
     #[test]
     fn test_from_ref() {
-        let mut data = [0.0_f32; 100];
-        let value: SystemMatrixBuffer<5, f32, _> = data.as_mut().into();
+        let data = [0.0_f32; 100];
+        let value: SystemMatrixBuffer<5, f32, _> = data.as_ref().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
     }
@@ -310,7 +310,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mut_from_ref() {
+    fn test_mut_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: SystemMatrixMutBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);

--- a/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/system_matrix_buffer.rs
@@ -83,6 +83,11 @@ where
     pub const fn is_empty(&self) -> bool {
         STATES * STATES == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const STATES: usize, T, M> AsRef<[T]> for SystemMatrixBuffer<STATES, T, M>

--- a/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::TemporaryBQMatrix;
 
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct TemporaryBQMatrixBuffer<const STATES: usize, const INPUTS: usize, T, M>(
@@ -27,14 +27,14 @@ impl<'a, const STATES: usize, const INPUTS: usize, T> From<&'a mut [T]>
 }
 
 impl<const STATES: usize, const INPUTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
-    for TemporaryBQMatrixBuffer<STATES, INPUTS, T, MatrixDataOwned<STATES, INPUTS, TOTAL, T>>
+    for TemporaryBQMatrixBuffer<STATES, INPUTS, T, MatrixDataArray<STATES, INPUTS, TOTAL, T>>
 {
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
             debug_assert_eq!(STATES * INPUTS, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<STATES, INPUTS, TOTAL, T>(value))
+        Self::new(MatrixData::new_array::<STATES, INPUTS, TOTAL, T>(value))
     }
 }
 

--- a/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
@@ -20,7 +20,7 @@ impl<'a, const STATES: usize, const INPUTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * INPUTS, value.len());
+            debug_assert!(STATES * INPUTS <= value.len());
         }
         Self::new(MatrixData::new_mut::<STATES, INPUTS, T>(value))
     }
@@ -32,7 +32,7 @@ impl<const STATES: usize, const INPUTS: usize, const TOTAL: usize, T> From<[T; T
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * INPUTS, TOTAL);
+            debug_assert!(STATES * INPUTS <= TOTAL);
         }
         Self::new(MatrixData::new_array::<STATES, INPUTS, TOTAL, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
@@ -5,6 +5,20 @@ use minikalman_traits::kalman::TemporaryBQMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Mutable buffer for the temporary B×Q matrix (`num_states` × `num_inputs`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = TemporaryBQMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = TemporaryBQMatrixBuffer::<2, 2, f32, _>::from(data.as_mut());
+/// ```
 pub struct TemporaryBQMatrixBuffer<const STATES: usize, const INPUTS: usize, T, M>(
     M,
     PhantomData<T>,

--- a/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
@@ -55,6 +55,11 @@ where
     pub const fn is_empty(&self) -> bool {
         STATES * INPUTS == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const STATES: usize, const INPUTS: usize, T, M> AsRef<[T]>

--- a/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use minikalman_traits::kalman::TemporaryBQMatrix;
 
+use minikalman_traits::kalman::TemporaryBQMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -146,5 +146,32 @@ where
 
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: TemporaryBQMatrixBuffer<5, 3, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 15);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: TemporaryBQMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 15);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: TemporaryBQMatrixBuffer<5, 3, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
     }
 }

--- a/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
@@ -175,7 +175,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: TemporaryBQMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);

--- a/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
@@ -180,6 +180,7 @@ mod tests {
         let value: TemporaryBQMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_bq_matrix_buffer.rs
@@ -171,6 +171,7 @@ mod tests {
     fn test_from_array() {
         let value: TemporaryBQMatrixBuffer<5, 3, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -179,6 +180,7 @@ mod tests {
         let mut data = [0.0_f32; 100];
         let value: TemporaryBQMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
@@ -63,6 +63,11 @@ where
     pub const fn is_empty(&self) -> bool {
         MEASUREMENTS * STATES == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const MEASUREMENTS: usize, const STATES: usize, T, M> AsRef<[T]>

--- a/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
@@ -183,6 +183,7 @@ mod tests {
     fn test_from_array() {
         let value: TemporaryHPMatrixBuffer<5, 3, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -191,6 +192,7 @@ mod tests {
         let mut data = [0.0_f32; 100];
         let value: TemporaryHPMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
@@ -20,7 +20,7 @@ impl<'a, const MEASUREMENTS: usize, const STATES: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * STATES, value.len());
+            debug_assert!(MEASUREMENTS * STATES <= value.len());
         }
         Self::new(MatrixData::new_mut::<MEASUREMENTS, STATES, T>(value))
     }
@@ -37,7 +37,7 @@ impl<const MEASUREMENTS: usize, const STATES: usize, const TOTAL: usize, T> From
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * STATES, TOTAL);
+            debug_assert!(MEASUREMENTS * STATES <= TOTAL);
         }
         Self::new(MatrixData::new_array::<MEASUREMENTS, STATES, TOTAL, T>(
             value,

--- a/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
@@ -5,6 +5,23 @@ use minikalman_traits::kalman::TemporaryHPMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Mutable buffer for the temporary H×P matrix (`num_measurements` × `num_states`).
+///
+/// # See also
+/// * [`TemporaryPHTMatrixBuffer`](crate::buffer_types::TemporaryPHTMatrixBuffer).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = TemporaryHPMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = TemporaryHPMatrixBuffer::<2, 2, f32, _>::from(data.as_mut());
+/// ```
 pub struct TemporaryHPMatrixBuffer<const MEASUREMENTS: usize, const STATES: usize, T, M>(
     M,
     PhantomData<T>,

--- a/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
@@ -187,7 +187,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: TemporaryHPMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);

--- a/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
@@ -192,6 +192,7 @@ mod tests {
         let value: TemporaryHPMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use minikalman_traits::kalman::TemporaryHPMatrix;
 
+use minikalman_traits::kalman::TemporaryHPMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -155,5 +155,32 @@ where
 
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: TemporaryHPMatrixBuffer<5, 3, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 15);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: TemporaryHPMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 15);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: TemporaryHPMatrixBuffer<5, 3, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
     }
 }

--- a/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_hp_matrix_buffer.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::TemporaryHPMatrix;
 
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct TemporaryHPMatrixBuffer<const MEASUREMENTS: usize, const STATES: usize, T, M>(
@@ -31,7 +31,7 @@ impl<const MEASUREMENTS: usize, const STATES: usize, const TOTAL: usize, T> From
         MEASUREMENTS,
         STATES,
         T,
-        MatrixDataOwned<MEASUREMENTS, STATES, TOTAL, T>,
+        MatrixDataArray<MEASUREMENTS, STATES, TOTAL, T>,
     >
 {
     fn from(value: [T; TOTAL]) -> Self {
@@ -39,7 +39,7 @@ impl<const MEASUREMENTS: usize, const STATES: usize, const TOTAL: usize, T> From
         {
             debug_assert_eq!(MEASUREMENTS * STATES, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<MEASUREMENTS, STATES, TOTAL, T>(
+        Self::new(MatrixData::new_array::<MEASUREMENTS, STATES, TOTAL, T>(
             value,
         ))
     }

--- a/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
@@ -165,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: TemporaryKHPMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);

--- a/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::TemporaryKHPMatrix;
 
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct TemporaryKHPMatrixBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
@@ -24,14 +24,14 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
 }
 
 impl<const STATES: usize, const TOTAL: usize, T> From<[T; TOTAL]>
-    for TemporaryKHPMatrixBuffer<STATES, T, MatrixDataOwned<STATES, STATES, TOTAL, T>>
+    for TemporaryKHPMatrixBuffer<STATES, T, MatrixDataArray<STATES, STATES, TOTAL, T>>
 {
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
             debug_assert_eq!(STATES * STATES, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<STATES, STATES, TOTAL, T>(value))
+        Self::new(MatrixData::new_array::<STATES, STATES, TOTAL, T>(value))
     }
 }
 

--- a/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
@@ -5,6 +5,20 @@ use minikalman_traits::kalman::TemporaryKHPMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Mutable buffer for the temporary K×H×P matrix (`num_states` × `num_states`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = TemporaryKHPMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = TemporaryKHPMatrixBuffer::<2, f32, _>::from(data.as_mut());
+/// ```
 pub struct TemporaryKHPMatrixBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<STATES, STATES, T>;

--- a/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use minikalman_traits::kalman::TemporaryKHPMatrix;
 
+use minikalman_traits::kalman::TemporaryKHPMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -136,5 +136,32 @@ where
 
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: TemporaryKHPMatrixBuffer<5, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: TemporaryKHPMatrixBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: TemporaryKHPMatrixBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
     }
 }

--- a/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
@@ -17,7 +17,7 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * STATES, value.len());
+            debug_assert!(STATES * STATES <= value.len());
         }
         Self::new(MatrixData::new_mut::<STATES, STATES, T>(value))
     }
@@ -29,7 +29,7 @@ impl<const STATES: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * STATES, TOTAL);
+            debug_assert!(STATES * STATES <= TOTAL);
         }
         Self::new(MatrixData::new_array::<STATES, STATES, TOTAL, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
@@ -161,6 +161,7 @@ mod tests {
     fn test_from_array() {
         let value: TemporaryKHPMatrixBuffer<5, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -169,6 +170,7 @@ mod tests {
         let mut data = [0.0_f32; 100];
         let value: TemporaryKHPMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
@@ -170,6 +170,7 @@ mod tests {
         let value: TemporaryKHPMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_khp_matrix_buffer.rs
@@ -52,6 +52,11 @@ where
     pub const fn is_empty(&self) -> bool {
         STATES * STATES == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const STATES: usize, T, M> AsRef<[T]> for TemporaryKHPMatrixBuffer<STATES, T, M>

--- a/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::TemporaryPHTMatrix;
 
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct TemporaryPHTMatrixBuffer<const STATES: usize, const MEASUREMENTS: usize, T, M>(
@@ -36,7 +36,7 @@ impl<const STATES: usize, const MEASUREMENTS: usize, const TOTAL: usize, T> From
         STATES,
         MEASUREMENTS,
         T,
-        MatrixDataOwned<STATES, MEASUREMENTS, TOTAL, T>,
+        MatrixDataArray<STATES, MEASUREMENTS, TOTAL, T>,
     >
 {
     fn from(value: [T; TOTAL]) -> Self {
@@ -44,7 +44,7 @@ impl<const STATES: usize, const MEASUREMENTS: usize, const TOTAL: usize, T> From
         {
             debug_assert_eq!(STATES * MEASUREMENTS, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<STATES, MEASUREMENTS, TOTAL, T>(
+        Self::new(MatrixData::new_array::<STATES, MEASUREMENTS, TOTAL, T>(
             value,
         ))
     }

--- a/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
@@ -5,6 +5,23 @@ use minikalman_traits::kalman::TemporaryPHTMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Mutable buffer for the temporary P×Hᵀ matrix (`num_states` × `num_measurements`).
+///
+/// # See also
+/// * [`TemporaryHPMatrixBuffer`](crate::buffer_types::TemporaryHPMatrixBuffer).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = TemporaryHPMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = TemporaryHPMatrixBuffer::<2, 2, f32, _>::from(data.as_mut());
+/// ```
 pub struct TemporaryPHTMatrixBuffer<const STATES: usize, const MEASUREMENTS: usize, T, M>(
     M,
     PhantomData<T>,

--- a/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
@@ -197,6 +197,7 @@ mod tests {
         let value: TemporaryPHTMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
@@ -192,7 +192,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: TemporaryPHTMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);

--- a/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
@@ -188,6 +188,7 @@ mod tests {
     fn test_from_array() {
         let value: TemporaryPHTMatrixBuffer<5, 3, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -196,6 +197,7 @@ mod tests {
         let mut data = [0.0_f32; 100];
         let value: TemporaryPHTMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 15);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use minikalman_traits::kalman::TemporaryPHTMatrix;
 
+use minikalman_traits::kalman::TemporaryPHTMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -160,5 +160,32 @@ where
 
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: TemporaryPHTMatrixBuffer<5, 3, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 15);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: TemporaryPHTMatrixBuffer<5, 3, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 15);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: TemporaryPHTMatrixBuffer<5, 3, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
     }
 }

--- a/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
@@ -25,7 +25,7 @@ impl<'a, const STATES: usize, const MEASUREMENTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * MEASUREMENTS, value.len());
+            debug_assert!(STATES * MEASUREMENTS <= value.len());
         }
         Self::new(MatrixData::new_mut::<STATES, MEASUREMENTS, T>(value))
     }
@@ -42,7 +42,7 @@ impl<const STATES: usize, const MEASUREMENTS: usize, const TOTAL: usize, T> From
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * MEASUREMENTS, TOTAL);
+            debug_assert!(STATES * MEASUREMENTS <= TOTAL);
         }
         Self::new(MatrixData::new_array::<STATES, MEASUREMENTS, TOTAL, T>(
             value,

--- a/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_pht_matrix_buffer.rs
@@ -68,6 +68,11 @@ where
     pub const fn is_empty(&self) -> bool {
         STATES * MEASUREMENTS == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const STATES: usize, const MEASUREMENTS: usize, T, M> AsRef<[T]>

--- a/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use minikalman_traits::kalman::TemporaryResidualCovarianceInvertedMatrix;
 
+use minikalman_traits::kalman::TemporaryResidualCovarianceInvertedMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -155,5 +155,33 @@ where
 
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: TemporaryResidualCovarianceInvertedMatrixBuffer<5, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: TemporaryResidualCovarianceInvertedMatrixBuffer<5, f32, _> =
+            data.as_mut().into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: TemporaryResidualCovarianceInvertedMatrixBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
     }
 }

--- a/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
@@ -180,6 +180,7 @@ mod tests {
     fn test_from_array() {
         let value: TemporaryResidualCovarianceInvertedMatrixBuffer<5, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -189,6 +190,7 @@ mod tests {
         let value: TemporaryResidualCovarianceInvertedMatrixBuffer<5, f32, _> =
             data.as_mut().into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::TemporaryResidualCovarianceInvertedMatrix;
 
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct TemporaryResidualCovarianceInvertedMatrixBuffer<const MEASUREMENTS: usize, T, M>(
@@ -34,7 +34,7 @@ impl<const MEASUREMENTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     for TemporaryResidualCovarianceInvertedMatrixBuffer<
         MEASUREMENTS,
         T,
-        MatrixDataOwned<MEASUREMENTS, MEASUREMENTS, TOTAL, T>,
+        MatrixDataArray<MEASUREMENTS, MEASUREMENTS, TOTAL, T>,
     >
 {
     fn from(value: [T; TOTAL]) -> Self {
@@ -42,7 +42,7 @@ impl<const MEASUREMENTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
         {
             debug_assert_eq!(MEASUREMENTS * MEASUREMENTS, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<MEASUREMENTS, MEASUREMENTS, TOTAL, T>(value))
+        Self::new(MatrixData::new_array::<MEASUREMENTS, MEASUREMENTS, TOTAL, T>(value))
     }
 }
 

--- a/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
@@ -24,7 +24,7 @@ impl<'a, const MEASUREMENTS: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * MEASUREMENTS, value.len());
+            debug_assert!(MEASUREMENTS * MEASUREMENTS <= value.len());
         }
         Self::new(MatrixData::new_mut::<MEASUREMENTS, MEASUREMENTS, T>(value))
     }
@@ -40,7 +40,7 @@ impl<const MEASUREMENTS: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(MEASUREMENTS * MEASUREMENTS, TOTAL);
+            debug_assert!(MEASUREMENTS * MEASUREMENTS <= TOTAL);
         }
         Self::new(MatrixData::new_array::<MEASUREMENTS, MEASUREMENTS, TOTAL, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
@@ -5,6 +5,20 @@ use minikalman_traits::kalman::TemporaryResidualCovarianceInvertedMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Mutable buffer for the temporary inverted innovation residual covariance matrix (`num_measurements` × `num_measurements`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = TemporaryResidualCovarianceInvertedMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = TemporaryResidualCovarianceInvertedMatrixBuffer::<2, f32, _>::from(data.as_mut());
+/// ```
 pub struct TemporaryResidualCovarianceInvertedMatrixBuffer<const MEASUREMENTS: usize, T, M>(
     M,
     PhantomData<T>,

--- a/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
@@ -64,6 +64,11 @@ where
     pub const fn is_empty(&self) -> bool {
         MEASUREMENTS * MEASUREMENTS == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const MEASUREMENTS: usize, T, M> AsRef<[T]>

--- a/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
@@ -184,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: TemporaryResidualCovarianceInvertedMatrixBuffer<5, f32, _> =
             data.as_mut().into();

--- a/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_residual_covariance_inverted_matrix_buffer.rs
@@ -190,6 +190,7 @@ mod tests {
             data.as_mut().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
@@ -5,6 +5,20 @@ use minikalman_traits::kalman::TemporaryStateMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
+/// Mutable buffer for the temporary system matrix (`num_states` × `num_states`).
+///
+/// ## Example
+/// ```
+/// use minikalman::prelude::*;
+/// use minikalman_traits::matrix::MatrixData;
+///
+/// // From owned data
+/// let buffer = TemporaryStateMatrixBuffer::new(MatrixData::new_array::<2, 2, 4, f32>([0.0; 4]));
+///
+/// // From a reference
+/// let mut data = [0.0; 4];
+/// let buffer = TemporaryStateMatrixBuffer::<2, f32, _>::from(data.as_mut());
+/// ```
 pub struct TemporaryStateMatrixBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
 where
     M: MatrixMut<STATES, STATES, T>;

--- a/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
@@ -52,6 +52,11 @@ where
     pub const fn is_empty(&self) -> bool {
         STATES * STATES == 0
     }
+
+    /// Ensures the underlying buffer has enough space for the expected number of values.
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid()
+    }
 }
 
 impl<const STATES: usize, T, M> AsRef<[T]> for TemporaryStateMatrixBuffer<STATES, T, M>

--- a/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
@@ -172,6 +172,7 @@ mod tests {
         let value: TemporaryStateMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
         assert!(value.is_valid());
+        assert!(core::ptr::eq(value.as_ref(), &data));
     }
 
     #[test]

--- a/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
@@ -167,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_ref() {
+    fn test_from_mut() {
         let mut data = [0.0_f32; 100];
         let value: TemporaryStateMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);

--- a/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
@@ -163,6 +163,7 @@ mod tests {
     fn test_from_array() {
         let value: TemporaryStateMatrixBuffer<5, f32, _> = [0.0; 100].into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
     }
 
@@ -171,6 +172,7 @@ mod tests {
         let mut data = [0.0_f32; 100];
         let value: TemporaryStateMatrixBuffer<5, f32, _> = data.as_mut().into();
         assert_eq!(value.len(), 25);
+        assert!(!value.is_empty());
         assert!(value.is_valid());
         assert!(core::ptr::eq(value.as_ref(), &data));
     }

--- a/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
@@ -17,7 +17,7 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
     fn from(value: &'a mut [T]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * STATES, value.len());
+            debug_assert!(STATES * STATES <= value.len());
         }
         Self::new(MatrixData::new_mut::<STATES, STATES, T>(value))
     }
@@ -29,7 +29,7 @@ impl<const STATES: usize, const TOTAL: usize, T> From<[T; TOTAL]>
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
-            debug_assert_eq!(STATES * STATES, TOTAL);
+            debug_assert!(STATES * STATES <= TOTAL);
         }
         Self::new(MatrixData::new_array::<STATES, STATES, TOTAL, T>(value))
     }

--- a/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
-use minikalman_traits::kalman::TemporaryStateMatrix;
 
+use minikalman_traits::kalman::TemporaryStateMatrix;
 use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
@@ -138,5 +138,32 @@ where
 
     fn into_inner(self) -> Self::Target {
         self.0.into_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_array() {
+        let value: TemporaryStateMatrixBuffer<5, f32, _> = [0.0; 100].into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    fn test_from_ref() {
+        let mut data = [0.0_f32; 100];
+        let value: TemporaryStateMatrixBuffer<5, f32, _> = data.as_mut().into();
+        assert_eq!(value.len(), 25);
+        assert!(value.is_valid());
+    }
+
+    #[test]
+    #[cfg(feature = "no_assert")]
+    fn test_from_array_invalid_size() {
+        let value: TemporaryStateMatrixBuffer<5, f32, _> = [0.0; 1].into();
+        assert!(!value.is_valid());
     }
 }

--- a/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
+++ b/crates/minikalman/src/buffer_types/temporary_state_matrix_buffer.rs
@@ -2,7 +2,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::kalman::TemporaryStateMatrix;
 
-use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataMut, MatrixDataOwned};
+use minikalman_traits::matrix::{IntoInnerData, MatrixData, MatrixDataArray, MatrixDataMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
 
 pub struct TemporaryStateMatrixBuffer<const STATES: usize, T, M>(M, PhantomData<T>)
@@ -24,14 +24,14 @@ impl<'a, const STATES: usize, T> From<&'a mut [T]>
 }
 
 impl<const STATES: usize, const TOTAL: usize, T> From<[T; TOTAL]>
-    for TemporaryStateMatrixBuffer<STATES, T, MatrixDataOwned<STATES, STATES, TOTAL, T>>
+    for TemporaryStateMatrixBuffer<STATES, T, MatrixDataArray<STATES, STATES, TOTAL, T>>
 {
     fn from(value: [T; TOTAL]) -> Self {
         #[cfg(not(feature = "no_assert"))]
         {
             debug_assert_eq!(STATES * STATES, TOTAL);
         }
-        Self::new(MatrixData::new_owned::<STATES, STATES, TOTAL, T>(value))
+        Self::new(MatrixData::new_array::<STATES, STATES, TOTAL, T>(value))
     }
 }
 

--- a/crates/minikalman/src/inputs.rs
+++ b/crates/minikalman/src/inputs.rs
@@ -202,7 +202,7 @@ where
     #[allow(non_snake_case)]
     pub fn apply_input<X, P>(&mut self, x: &mut X, P: &mut P)
     where
-        X: StateVector<STATES, T>,
+        X: StateVectorMut<STATES, T>,
         P: SystemCovarianceMatrix<STATES, T>,
     {
         // matrices and vectors
@@ -236,7 +236,7 @@ impl<const STATES: usize, const INPUTS: usize, T, B, U, Q, TempBQ> KalmanFilterN
 {
 }
 
-impl<const STATES: usize, const INPUTS: usize, T, B, U, Q, TempBQ> KalmanFilterNumInputs<STATES>
+impl<const STATES: usize, const INPUTS: usize, T, B, U, Q, TempBQ> KalmanFilterNumInputs<INPUTS>
     for Input<STATES, INPUTS, T, B, U, Q, TempBQ>
 {
 }
@@ -325,7 +325,7 @@ where
     #[allow(non_snake_case)]
     fn apply_to<X, P>(&mut self, x: &mut X, P: &mut P)
     where
-        X: StateVector<STATES, T>,
+        X: StateVectorMut<STATES, T>,
         P: SystemCovarianceMatrix<STATES, T>,
     {
         self.apply_input(x, P)

--- a/crates/minikalman/src/inputs.rs
+++ b/crates/minikalman/src/inputs.rs
@@ -336,9 +336,9 @@ where
 #[cfg(feature = "float")]
 mod tests {
     use super::*;
+    use crate::test_dummies::{Dummy, DummyMatrix};
     use assert_float_eq::*;
-    use core::ops::{Index, IndexMut};
-    use minikalman_traits::matrix::{Matrix, MatrixMut};
+    use minikalman_traits::matrix::MatrixMut;
 
     #[allow(non_snake_case)]
     #[test]
@@ -460,12 +460,6 @@ mod tests {
         );
     }
 
-    #[derive(Default)]
-    struct Dummy<T>(DummyMatrix<T>, PhantomData<T>);
-
-    #[derive(Default)]
-    struct DummyMatrix<T>(PhantomData<T>);
-
     impl<const INPUTS: usize, T> InputVector<INPUTS, T> for Dummy<T> {
         type Target = DummyMatrix<T>;
 
@@ -523,33 +517,4 @@ mod tests {
             &mut self.0
         }
     }
-
-    impl<T> AsRef<[T]> for DummyMatrix<T> {
-        fn as_ref(&self) -> &[T] {
-            todo!()
-        }
-    }
-
-    impl<T> AsMut<[T]> for DummyMatrix<T> {
-        fn as_mut(&mut self) -> &mut [T] {
-            todo!()
-        }
-    }
-
-    impl<T> Index<usize> for DummyMatrix<T> {
-        type Output = T;
-
-        fn index(&self, _index: usize) -> &Self::Output {
-            todo!()
-        }
-    }
-
-    impl<T> IndexMut<usize> for DummyMatrix<T> {
-        fn index_mut(&mut self, _index: usize) -> &mut Self::Output {
-            todo!()
-        }
-    }
-
-    impl<const ROWS: usize, const COLS: usize, T> Matrix<ROWS, COLS, T> for DummyMatrix<T> {}
-    impl<const ROWS: usize, const COLS: usize, T> MatrixMut<ROWS, COLS, T> for DummyMatrix<T> {}
 }

--- a/crates/minikalman/src/inputs.rs
+++ b/crates/minikalman/src/inputs.rs
@@ -333,17 +333,17 @@ where
 }
 
 #[cfg(test)]
-#[cfg(feature = "float")]
 mod tests {
     use super::*;
     use crate::test_dummies::{Dummy, DummyMatrix};
-    use assert_float_eq::*;
-    use minikalman_traits::matrix::MatrixMut;
 
     #[allow(non_snake_case)]
     #[test]
     #[cfg(feature = "alloc")]
     fn input_only() {
+        use assert_float_eq::*;
+        use minikalman_traits::matrix::MatrixMut;
+
         use crate::prelude::{BufferBuilder, KalmanBuilder};
 
         const NUM_STATES: usize = 4;
@@ -450,7 +450,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "float")]
     fn builder_simple() {
         let _filter = InputBuilder::new::<3, 2, f32>(
             Dummy::default(),

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -693,7 +693,6 @@ where
 }
 
 #[cfg(test)]
-#[cfg(feature = "float")]
 mod tests {
     use super::*;
     use crate::test_dummies::{Dummy, DummyMatrix};

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -65,7 +65,7 @@ impl<A, X, P, PX, TempP> KalmanBuilder<A, X, P, PX, TempP> {
     where
         T: MatrixDataType,
         A: SystemMatrix<STATES, T>,
-        X: StateVector<STATES, T>,
+        X: StateVectorMut<STATES, T>,
         P: SystemCovarianceMatrix<STATES, T>,
         PX: StatePredictionVector<STATES, T>,
         TempP: TemporaryStateMatrix<STATES, T>,
@@ -275,7 +275,7 @@ impl<const STATES: usize, T, A, X, P, PX, TempP> Kalman<STATES, T, A, X, P, PX, 
     #[doc(alias = "kalman_predict")]
     pub fn predict(&mut self)
     where
-        X: StateVector<STATES, T>,
+        X: StateVectorMut<STATES, T>,
         A: SystemMatrix<STATES, T>,
         PX: StatePredictionVector<STATES, T>,
         P: SystemCovarianceMatrix<STATES, T>,
@@ -372,7 +372,7 @@ impl<const STATES: usize, T, A, X, P, PX, TempP> Kalman<STATES, T, A, X, P, PX, 
     #[doc(alias = "kalman_predict_tuned")]
     pub fn predict_tuned(&mut self, lambda: T)
     where
-        X: StateVector<STATES, T>,
+        X: StateVectorMut<STATES, T>,
         A: SystemMatrix<STATES, T>,
         PX: StatePredictionVector<STATES, T>,
         P: SystemCovarianceMatrix<STATES, T>,
@@ -396,7 +396,7 @@ impl<const STATES: usize, T, A, X, P, PX, TempP> Kalman<STATES, T, A, X, P, PX, 
     #[doc(alias = "kalman_predict_x")]
     fn predict_x(&mut self)
     where
-        X: StateVector<STATES, T>,
+        X: StateVectorMut<STATES, T>,
         A: SystemMatrix<STATES, T>,
         PX: StatePredictionVector<STATES, T>,
         T: MatrixDataType,
@@ -469,7 +469,7 @@ impl<const STATES: usize, T, A, X, P, PX, TempP> Kalman<STATES, T, A, X, P, PX, 
     pub fn input<const INPUTS: usize, I>(&mut self, input: &mut I)
     where
         P: SystemCovarianceMatrix<STATES, T>,
-        X: StateVector<STATES, T>,
+        X: StateVectorMut<STATES, T>,
         T: MatrixDataType,
         I: KalmanFilterInputApplyToFilter<STATES, T> + KalmanFilterNumInputs<INPUTS>,
     {
@@ -551,7 +551,7 @@ impl<const STATES: usize, T, A, X, P, PX, TempP> Kalman<STATES, T, A, X, P, PX, 
     pub fn correct<const MEASUREMENTS: usize, M>(&mut self, measurement: &mut M)
     where
         P: SystemCovarianceMatrix<STATES, T>,
-        X: StateVector<STATES, T>,
+        X: StateVectorMut<STATES, T>,
         T: MatrixDataType,
         M: KalmanFilterMeasurementCorrectFilter<STATES, T>
             + KalmanFilterNumMeasurements<MEASUREMENTS>,
@@ -581,7 +581,7 @@ where
 impl<const STATES: usize, T, A, X, P, PX, TempP> KalmanFilterStateVectorMut<STATES, T>
     for Kalman<STATES, T, A, X, P, PX, TempP>
 where
-    X: StateVector<STATES, T>,
+    X: StateVectorMut<STATES, T>,
 {
     type StateVectorMut = X;
 
@@ -646,7 +646,7 @@ where
 impl<const STATES: usize, T, A, X, P, PX, TempP> KalmanFilterPredict<STATES, T>
     for Kalman<STATES, T, A, X, P, PX, TempP>
 where
-    X: StateVector<STATES, T>,
+    X: StateVectorMut<STATES, T>,
     A: SystemMatrix<STATES, T>,
     PX: StatePredictionVector<STATES, T>,
     P: SystemCovarianceMatrix<STATES, T>,
@@ -663,7 +663,7 @@ impl<const STATES: usize, T, A, X, P, PX, TempP> KalmanFilterUpdate<STATES, T>
     for Kalman<STATES, T, A, X, P, PX, TempP>
 where
     P: SystemCovarianceMatrix<STATES, T>,
-    X: StateVector<STATES, T>,
+    X: StateVectorMut<STATES, T>,
     T: MatrixDataType,
 {
     #[inline(always)]
@@ -680,7 +680,7 @@ impl<const STATES: usize, T, A, X, P, PX, TempP> KalmanFilterApplyInput<STATES, 
     for Kalman<STATES, T, A, X, P, PX, TempP>
 where
     P: SystemCovarianceMatrix<STATES, T>,
-    X: StateVector<STATES, T>,
+    X: StateVectorMut<STATES, T>,
     T: MatrixDataType,
 {
     #[inline(always)]
@@ -710,16 +710,18 @@ mod tests {
 
     impl<const STATES: usize, T> StateVector<STATES, T> for Dummy<T> {
         type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
         fn as_matrix(&self) -> &Self::Target {
             &self.0
         }
+    }
 
+    impl<const STATES: usize, T> StateVectorMut<STATES, T> for Dummy<T> {
+        type TargetMut = DummyMatrix<T>;
         fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
             &mut self.0
         }
     }
+
     impl<const STATES: usize, T> SystemMatrix<STATES, T> for Dummy<T> {
         type Target = DummyMatrix<T>;
 

--- a/crates/minikalman/src/kalman_builder.rs
+++ b/crates/minikalman/src/kalman_builder.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use minikalman_traits::kalman::{
     InnovationVector, InputCovarianceMatrixMut, InputMatrixMut, InputVectorMut, KalmanGainMatrix,
@@ -16,14 +16,17 @@ use crate::buffer_builder::{
 use crate::inputs::{Input, InputBuilder};
 use crate::{BufferBuilder, Kalman, KalmanBuilder, Measurement, MeasurementBuilder};
 
+/// A simple builder for [`Kalman`] instances.
 #[derive(Copy, Clone)]
 pub struct KalmanFilterBuilder<const STATES: usize, T>(PhantomData<T>);
 
-#[derive(Copy, Clone)]
-pub struct KalmanFilterMeasurementBuilder<const STATES: usize, T>(PhantomData<T>);
-
+/// A simple builder for [`Input`] instances.
 #[derive(Copy, Clone)]
 pub struct KalmanFilterInputBuilder<const STATES: usize, T>(PhantomData<T>);
+
+/// A simple builder for [`Measurement`] instances.
+#[derive(Copy, Clone)]
+pub struct KalmanFilterMeasurementBuilder<const STATES: usize, T>(PhantomData<T>);
 
 impl<const STATES: usize, T> Default for KalmanFilterBuilder<STATES, T> {
     fn default() -> Self {

--- a/crates/minikalman/src/kalman_builder.rs
+++ b/crates/minikalman/src/kalman_builder.rs
@@ -1,6 +1,5 @@
 use core::marker::PhantomData;
 
-use minikalman_traits::kalman::*;
 use minikalman_traits::matrix::MatrixDataType;
 
 use crate::buffer_builder::*;
@@ -27,7 +26,7 @@ impl<const STATES: usize, T> Default for KalmanFilterBuilder<STATES, T> {
 
 /// The type of Kalman filters with owned buffers.
 ///
-/// See also the [`KalmanFilter`] trait.
+/// See also the [`KalmanFilter`](minikalman_traits::kalman::KalmanFilter) trait.
 pub type KalmanFilterType<const STATES: usize, T> = Kalman<
     STATES,
     T,
@@ -103,9 +102,9 @@ impl<const STATES: usize, T> Default for KalmanFilterInputBuilder<STATES, T> {
     }
 }
 
-/// The type of Kalman filters with owned buffers.
+/// The type of Kalman filter inputs with owned buffers.
 ///
-/// See also the [`KalmanFilter`] trait.
+/// See also the [`KalmanFilterInput`](minikalman_traits::kalman::KalmanFilterInput) trait.
 pub type KalmanFilterInputType<const STATES: usize, const INPUTS: usize, T> = Input<
     STATES,
     INPUTS,
@@ -167,6 +166,26 @@ impl<const STATES: usize, T> Default for KalmanFilterMeasurementBuilder<STATES, 
     }
 }
 
+/// The type of Kalman filter measurements with owned buffers.
+///
+/// See also the [`KalmanFilterMeasurement`](minikalman_traits::kalman::KalmanFilterMeasurement) trait.
+pub type KalmanFilterMeasurementType<const STATES: usize, const MEASUREMENTS: usize, T> =
+    Measurement<
+        STATES,
+        MEASUREMENTS,
+        T,
+        ObservationMatrixBufferOwnedType<MEASUREMENTS, STATES, T>,
+        ObservationVectorBufferOwnedType<MEASUREMENTS, T>,
+        ObservationCovarianceBufferOwnedType<MEASUREMENTS, T>,
+        InnovationVectorBufferOwnedType<MEASUREMENTS, T>,
+        InnovationResidualCovarianceMatrixBufferOwnedType<MEASUREMENTS, T>,
+        KalmanGainMatrixBufferOwnedType<STATES, MEASUREMENTS, T>,
+        TemporarySInvertedMatrixBufferOwnedType<MEASUREMENTS, T>,
+        TemporaryHPMatrixBufferOwnedType<MEASUREMENTS, STATES, T>,
+        TemporaryPHtMatrixBufferOwnedType<STATES, MEASUREMENTS, T>,
+        TemporaryKHPMatrixBufferOwnedType<STATES, T>,
+    >;
+
 impl<const STATES: usize, T> KalmanFilterMeasurementBuilder<STATES, T> {
     /// Creates a new [`KalmanFilterMeasurementBuilder`] instance.
     pub fn new() -> Self {
@@ -190,21 +209,7 @@ impl<const STATES: usize, T> KalmanFilterMeasurementBuilder<STATES, T> {
     /// See also [`KalmanFilterBuilder`] and [`KalmanFilterInputBuilder`] for further information.
     pub fn build<const MEASUREMENTS: usize>(
         &self,
-    ) -> Measurement<
-        STATES,
-        MEASUREMENTS,
-        T,
-        impl MeasurementObservationMatrixMut<MEASUREMENTS, STATES, T>,
-        impl MeasurementVectorMut<MEASUREMENTS, T>,
-        impl MeasurementProcessNoiseCovarianceMatrix<MEASUREMENTS, T>,
-        impl InnovationVector<MEASUREMENTS, T>,
-        impl ResidualCovarianceMatrix<MEASUREMENTS, T>,
-        impl KalmanGainMatrix<STATES, MEASUREMENTS, T>,
-        impl TemporaryResidualCovarianceInvertedMatrix<MEASUREMENTS, T>,
-        impl TemporaryHPMatrix<MEASUREMENTS, STATES, T>,
-        impl TemporaryPHTMatrix<STATES, MEASUREMENTS, T>,
-        impl TemporaryKHPMatrix<STATES, T>,
-    >
+    ) -> KalmanFilterMeasurementType<STATES, MEASUREMENTS, T>
     where
         T: MatrixDataType,
     {
@@ -246,6 +251,7 @@ impl<const STATES: usize, T> KalmanFilterMeasurementBuilder<STATES, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use minikalman_traits::kalman::{KalmanFilter, KalmanFilterInput, KalmanFilterMeasurement};
 
     const NUM_STATES: usize = 3; // height, upwards velocity, upwards acceleration
     const NUM_INPUTS: usize = 1; // constant velocity

--- a/crates/minikalman/src/kalman_builder.rs
+++ b/crates/minikalman/src/kalman_builder.rs
@@ -1,18 +1,9 @@
 use core::marker::PhantomData;
 
-use minikalman_traits::kalman::{
-    InnovationVector, InputCovarianceMatrixMut, InputMatrixMut, InputVectorMut, KalmanGainMatrix,
-    MeasurementObservationMatrixMut, MeasurementProcessNoiseCovarianceMatrix, MeasurementVectorMut,
-    ResidualCovarianceMatrix, TemporaryBQMatrix, TemporaryHPMatrix, TemporaryKHPMatrix,
-    TemporaryPHTMatrix, TemporaryResidualCovarianceInvertedMatrix,
-};
+use minikalman_traits::kalman::*;
 use minikalman_traits::matrix::MatrixDataType;
 
-use crate::buffer_builder::{
-    StatePredictionVectorBufferOwnedType, StateVectorBufferOwnedType,
-    SystemCovarianceMatrixBufferOwnedType, SystemMatrixMutBufferOwnedType,
-    TemporarySystemCovarianceMatrixBufferOwnedType,
-};
+use crate::buffer_builder::*;
 use crate::inputs::{Input, InputBuilder};
 use crate::{BufferBuilder, Kalman, KalmanBuilder, Measurement, MeasurementBuilder};
 
@@ -35,6 +26,8 @@ impl<const STATES: usize, T> Default for KalmanFilterBuilder<STATES, T> {
 }
 
 /// The type of Kalman filters with owned buffers.
+///
+/// See also the [`KalmanFilter`] trait.
 pub type KalmanFilterType<const STATES: usize, T> = Kalman<
     STATES,
     T,

--- a/crates/minikalman/src/kalman_builder.rs
+++ b/crates/minikalman/src/kalman_builder.rs
@@ -30,7 +30,7 @@ pub struct KalmanFilterMeasurementBuilder<const STATES: usize, T>(PhantomData<T>
 
 impl<const STATES: usize, T> Default for KalmanFilterBuilder<STATES, T> {
     fn default() -> Self {
-        KalmanFilterBuilder(PhantomData)
+        KalmanFilterBuilder::new()
     }
 }
 
@@ -244,5 +244,37 @@ impl<const STATES: usize, T> KalmanFilterMeasurementBuilder<STATES, T> {
             temp_pht,
             temp_khp,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NUM_STATES: usize = 3; // height, upwards velocity, upwards acceleration
+    const NUM_INPUTS: usize = 1; // constant velocity
+    const NUM_MEASUREMENTS: usize = 1; // position
+
+    #[test]
+    fn kalman_builder() {
+        let builder = KalmanFilterBuilder::<NUM_STATES, f32>::default();
+        let filter = builder.build();
+        assert_eq!(filter.states(), NUM_STATES);
+    }
+
+    #[test]
+    fn input_builder() {
+        let builder = KalmanFilterBuilder::<NUM_STATES, f32>::default();
+        let input = builder.inputs().build::<NUM_INPUTS>();
+        assert_eq!(input.states(), NUM_STATES);
+        assert_eq!(input.inputs(), NUM_INPUTS);
+    }
+
+    #[test]
+    fn measurement_builder() {
+        let builder = KalmanFilterBuilder::<NUM_STATES, f32>::default();
+        let measurement = builder.measurements().build::<NUM_MEASUREMENTS>();
+        assert_eq!(measurement.states(), NUM_STATES);
+        assert_eq!(measurement.measurements(), NUM_INPUTS);
     }
 }

--- a/crates/minikalman/src/kalman_builder.rs
+++ b/crates/minikalman/src/kalman_builder.rs
@@ -34,8 +34,8 @@ pub type KalmanFilterType<const STATES: usize, T> = Kalman<
     SystemMatrixMutBufferOwnedType<STATES, T>,
     StateVectorBufferOwnedType<STATES, T>,
     SystemCovarianceMatrixBufferOwnedType<STATES, T>,
-    StatePredictionVectorBufferOwnedType<STATES, T>,
-    TemporarySystemCovarianceMatrixBufferOwnedType<STATES, T>,
+    TemporaryStatePredictionVectorBufferOwnedType<STATES, T>,
+    TemporaryStateMatrixBufferOwnedType<STATES, T>,
 >;
 
 impl<const STATES: usize, T> KalmanFilterBuilder<STATES, T> {
@@ -248,11 +248,30 @@ mod tests {
     const NUM_INPUTS: usize = 1; // constant velocity
     const NUM_MEASUREMENTS: usize = 1; // position
 
+    fn accept_filter<F, T>(_filter: F)
+    where
+        F: KalmanFilter<NUM_STATES, T>,
+    {
+    }
+
+    fn accept_input<I, T>(_input: I)
+    where
+        I: KalmanFilterInput<NUM_STATES, NUM_INPUTS, T>,
+    {
+    }
+
+    fn accept_measurement<M, T>(_measurement: M)
+    where
+        M: KalmanFilterMeasurement<NUM_STATES, NUM_MEASUREMENTS, T>,
+    {
+    }
+
     #[test]
     fn kalman_builder() {
         let builder = KalmanFilterBuilder::<NUM_STATES, f32>::default();
         let filter = builder.build();
         assert_eq!(filter.states(), NUM_STATES);
+        accept_filter(filter);
     }
 
     #[test]
@@ -261,6 +280,7 @@ mod tests {
         let input = builder.inputs().build::<NUM_INPUTS>();
         assert_eq!(input.states(), NUM_STATES);
         assert_eq!(input.inputs(), NUM_INPUTS);
+        accept_input(input);
     }
 
     #[test]
@@ -269,5 +289,6 @@ mod tests {
         let measurement = builder.measurements().build::<NUM_MEASUREMENTS>();
         assert_eq!(measurement.states(), NUM_STATES);
         assert_eq!(measurement.measurements(), NUM_INPUTS);
+        accept_measurement(measurement);
     }
 }

--- a/crates/minikalman/src/kalman_builder.rs
+++ b/crates/minikalman/src/kalman_builder.rs
@@ -103,6 +103,19 @@ impl<const STATES: usize, T> Default for KalmanFilterInputBuilder<STATES, T> {
     }
 }
 
+/// The type of Kalman filters with owned buffers.
+///
+/// See also the [`KalmanFilter`] trait.
+pub type KalmanFilterInputType<const STATES: usize, const INPUTS: usize, T> = Input<
+    STATES,
+    INPUTS,
+    T,
+    ControlMatrixBufferOwnedType<STATES, INPUTS, T>,
+    ControlVectorBufferOwnedType<INPUTS, T>,
+    ControlCovarianceMatrixBufferOwnedType<INPUTS, T>,
+    TemporaryBQMatrixBufferOwnedType<STATES, INPUTS, T>,
+>;
+
 impl<const STATES: usize, T> KalmanFilterInputBuilder<STATES, T> {
     /// Creates a new [`KalmanFilterInputBuilder`] instance.
     pub fn new() -> Self {
@@ -124,17 +137,7 @@ impl<const STATES: usize, T> KalmanFilterInputBuilder<STATES, T> {
     /// ```
     ///
     /// See also [`KalmanFilterBuilder`] and [`KalmanFilterMeasurementBuilder`] for further information.
-    pub fn build<const INPUTS: usize>(
-        &self,
-    ) -> Input<
-        STATES,
-        INPUTS,
-        T,
-        impl InputMatrixMut<STATES, INPUTS, T>,
-        impl InputVectorMut<INPUTS, T>,
-        impl InputCovarianceMatrixMut<INPUTS, T>,
-        impl TemporaryBQMatrix<STATES, INPUTS, T>,
-    >
+    pub fn build<const INPUTS: usize>(&self) -> KalmanFilterInputType<STATES, INPUTS, T>
     where
         T: MatrixDataType,
     {

--- a/crates/minikalman/src/kalman_builder.rs
+++ b/crates/minikalman/src/kalman_builder.rs
@@ -1,0 +1,188 @@
+use std::marker::PhantomData;
+
+use minikalman_traits::kalman::{
+    InnovationVector, InputCovarianceMatrixMut, InputMatrixMut, InputVectorMut, KalmanGainMatrix,
+    MeasurementObservationMatrixMut, MeasurementProcessNoiseCovarianceMatrix, MeasurementVectorMut,
+    ResidualCovarianceMatrix, StatePredictionVector, StateVector, SystemCovarianceMatrix,
+    SystemMatrixMut, TemporaryBQMatrix, TemporaryHPMatrix, TemporaryKHPMatrix, TemporaryPHTMatrix,
+    TemporaryResidualCovarianceInvertedMatrix, TemporaryStateMatrix,
+};
+use minikalman_traits::matrix::MatrixDataType;
+
+use crate::inputs::{Input, InputBuilder};
+use crate::{BufferBuilder, Kalman, KalmanBuilder, Measurement, MeasurementBuilder};
+
+#[derive(Copy, Clone)]
+pub struct KalmanFilterBuilder<const STATES: usize, T>(PhantomData<T>);
+
+#[derive(Copy, Clone)]
+pub struct KalmanFilterMeasurementBuilder<const STATES: usize, T>(PhantomData<T>);
+
+#[derive(Copy, Clone)]
+pub struct KalmanFilterInputBuilder<const STATES: usize, T>(PhantomData<T>);
+
+impl<const STATES: usize, T> Default for KalmanFilterBuilder<STATES, T> {
+    fn default() -> Self {
+        KalmanFilterBuilder(PhantomData)
+    }
+}
+
+impl<const STATES: usize, T> KalmanFilterBuilder<STATES, T> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+
+    pub fn build(
+        &self,
+    ) -> Kalman<
+        STATES,
+        T,
+        impl SystemMatrixMut<STATES, T>,
+        impl StateVector<STATES, T>,
+        impl SystemCovarianceMatrix<STATES, T>,
+        impl StatePredictionVector<STATES, T>,
+        impl TemporaryStateMatrix<STATES, T>,
+    >
+    where
+        T: MatrixDataType,
+    {
+        // The initialization value.
+        let zero = T::zero();
+
+        // System buffers.
+        let state_vector = BufferBuilder::state_vector_x::<STATES>().new(zero);
+        let system_matrix = BufferBuilder::system_state_transition_A::<STATES>().new(zero);
+        let system_covariance = BufferBuilder::system_covariance_P::<STATES>().new(zero);
+
+        // Filter temporaries.
+        let temp_x = BufferBuilder::state_prediction_temp_x::<STATES>().new(zero);
+        let temp_p = BufferBuilder::temp_system_covariance_P::<STATES>().new(zero);
+
+        KalmanBuilder::new::<STATES, T>(
+            system_matrix,
+            state_vector,
+            system_covariance,
+            temp_x,
+            temp_p,
+        )
+    }
+
+    pub fn measurements(&self) -> KalmanFilterMeasurementBuilder<STATES, T> {
+        Default::default()
+    }
+
+    pub fn inputs(&self) -> KalmanFilterInputBuilder<STATES, T> {
+        Default::default()
+    }
+}
+
+impl<const STATES: usize, T> Default for KalmanFilterInputBuilder<STATES, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const STATES: usize, T> KalmanFilterInputBuilder<STATES, T> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+
+    pub fn build<const INPUTS: usize>(
+        &self,
+    ) -> Input<
+        STATES,
+        INPUTS,
+        T,
+        impl InputMatrixMut<STATES, INPUTS, T>,
+        impl InputVectorMut<INPUTS, T>,
+        impl InputCovarianceMatrixMut<INPUTS, T>,
+        impl TemporaryBQMatrix<STATES, INPUTS, T>,
+    >
+    where
+        T: MatrixDataType,
+    {
+        // The initialization value.
+        let zero = T::zero();
+
+        // Input buffers.
+        let input_vector = BufferBuilder::input_vector_u::<INPUTS>().new(zero);
+        let input_transition = BufferBuilder::input_transition_B::<STATES, INPUTS>().new(zero);
+        let input_covariance = BufferBuilder::input_covariance_Q::<INPUTS>().new(zero);
+
+        // Input temporaries.
+        let temp_bq = BufferBuilder::temp_BQ::<STATES, INPUTS>().new(zero);
+
+        InputBuilder::new::<STATES, INPUTS, T>(
+            input_transition,
+            input_vector,
+            input_covariance,
+            temp_bq,
+        )
+    }
+}
+
+impl<const STATES: usize, T> Default for KalmanFilterMeasurementBuilder<STATES, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const STATES: usize, T> KalmanFilterMeasurementBuilder<STATES, T> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+
+    pub fn build<const MEASUREMENTS: usize>(
+        &self,
+    ) -> Measurement<
+        STATES,
+        MEASUREMENTS,
+        T,
+        impl MeasurementObservationMatrixMut<MEASUREMENTS, STATES, T>,
+        impl MeasurementVectorMut<MEASUREMENTS, T>,
+        impl MeasurementProcessNoiseCovarianceMatrix<MEASUREMENTS, T>,
+        impl InnovationVector<MEASUREMENTS, T>,
+        impl ResidualCovarianceMatrix<MEASUREMENTS, T>,
+        impl KalmanGainMatrix<STATES, MEASUREMENTS, T>,
+        impl TemporaryResidualCovarianceInvertedMatrix<MEASUREMENTS, T>,
+        impl TemporaryHPMatrix<MEASUREMENTS, STATES, T>,
+        impl TemporaryPHTMatrix<STATES, MEASUREMENTS, T>,
+        impl TemporaryKHPMatrix<STATES, T>,
+    >
+    where
+        T: MatrixDataType,
+    {
+        // The initialization value.
+        let zero = T::zero();
+
+        // Measurement buffers.
+        let measurement_vector = BufferBuilder::measurement_vector_z::<MEASUREMENTS>().new(zero);
+        let observation_matrix =
+            BufferBuilder::measurement_transformation_H::<MEASUREMENTS, STATES>().new(zero);
+        let observation_covariance =
+            BufferBuilder::measurement_covariance_R::<MEASUREMENTS>().new(zero);
+        let innovation_vector = BufferBuilder::innovation_vector_y::<MEASUREMENTS>().new(zero);
+        let residual_covariance_matrix =
+            BufferBuilder::innovation_covariance_S::<MEASUREMENTS>().new(zero);
+        let kalman_gain = BufferBuilder::kalman_gain_K::<STATES, MEASUREMENTS>().new(zero);
+
+        // Measurement temporaries.
+        let temp_s_inverted = BufferBuilder::temp_S_inv::<MEASUREMENTS>().new(zero);
+        let temp_hp = BufferBuilder::temp_HP::<MEASUREMENTS, STATES>().new(zero);
+        let temp_pht = BufferBuilder::temp_PHt::<STATES, MEASUREMENTS>().new(zero);
+        let temp_khp = BufferBuilder::temp_KHP::<STATES>().new(zero);
+
+        MeasurementBuilder::new::<STATES, MEASUREMENTS, T>(
+            observation_matrix,
+            measurement_vector,
+            observation_covariance,
+            innovation_vector,
+            residual_covariance_matrix,
+            kalman_gain,
+            temp_s_inverted,
+            temp_hp,
+            temp_pht,
+            temp_khp,
+        )
+    }
+}

--- a/crates/minikalman/src/lib.rs
+++ b/crates/minikalman/src/lib.rs
@@ -44,6 +44,7 @@ mod kalman;
 mod measurement;
 mod static_macros;
 
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(test)]
 mod test_dummies;
 

--- a/crates/minikalman/src/lib.rs
+++ b/crates/minikalman/src/lib.rs
@@ -34,11 +34,19 @@ extern crate alloc;
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]
 mod buffer_builder;
+
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[cfg(feature = "alloc")]
+mod kalman_builder;
+
 pub mod buffer_types;
 mod inputs;
 mod kalman;
 mod measurement;
 mod static_macros;
+
+#[cfg(test)]
+mod test_dummies;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]
@@ -52,6 +60,14 @@ pub use num_traits;
 pub mod traits {
     pub use minikalman_traits::kalman;
     pub use minikalman_traits::matrix;
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[cfg(feature = "alloc")]
+pub mod builder {
+    pub use crate::kalman_builder::{
+        KalmanFilterBuilder, KalmanFilterInputBuilder, KalmanFilterMeasurementBuilder,
+    };
 }
 
 /// Exports all macros and common types.

--- a/crates/minikalman/src/lib.rs
+++ b/crates/minikalman/src/lib.rs
@@ -13,7 +13,6 @@
 //! * `std` - Disabled by default. Disables the `no_std` configuration attribute (enabling `std` support).
 //! * `alloc` - Enables allocation support for builder types.
 //! * `libm` - Enables libm support.
-//! * `float` - Enables some in-built support for `f32` and `f64` support.
 //! * `fixed` - Enables fixed-point support via the [fixed](https://crates.io/crates/fixed) crate.
 //! * `unsafe` - Enables some unsafe pointer operations. Disabled by default; when turned off,
 //!              compiles the crate as `#![forbid(unsafe)]`.

--- a/crates/minikalman/src/measurement.rs
+++ b/crates/minikalman/src/measurement.rs
@@ -371,7 +371,7 @@ where
     #[allow(non_snake_case)]
     pub fn correct<X, P>(&mut self, x: &mut X, P: &mut P)
     where
-        X: StateVector<STATES, T>,
+        X: StateVectorMut<STATES, T>,
         P: SystemCovarianceMatrix<STATES, T>,
     {
         // matrices and vectors
@@ -692,7 +692,7 @@ where
     #[allow(non_snake_case)]
     fn correct<X, P>(&mut self, x: &mut X, P: &mut P)
     where
-        X: StateVector<STATES, T>,
+        X: StateVectorMut<STATES, T>,
         P: SystemCovarianceMatrix<STATES, T>,
     {
         self.correct(x, P)

--- a/crates/minikalman/src/measurement.rs
+++ b/crates/minikalman/src/measurement.rs
@@ -205,13 +205,13 @@ impl<
 {
     /// Returns then number of measurements.
     #[inline(always)]
-    pub const fn measurements() -> usize {
+    pub const fn measurements(&self) -> usize {
         MEASUREMENTS
     }
 
     /// Returns then number of states.
     #[inline(always)]
-    pub const fn states() -> usize {
+    pub const fn states(&self) -> usize {
         STATES
     }
 

--- a/crates/minikalman/src/measurement.rs
+++ b/crates/minikalman/src/measurement.rs
@@ -700,7 +700,6 @@ where
 }
 
 #[cfg(test)]
-#[cfg(feature = "float")]
 mod tests {
     use crate::test_dummies::{Dummy, DummyMatrix};
 

--- a/crates/minikalman/src/measurement.rs
+++ b/crates/minikalman/src/measurement.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+
 use minikalman_traits::kalman::*;
 use minikalman_traits::matrix::{Matrix, MatrixDataType, MatrixMut, SquareMatrix};
 
@@ -701,8 +702,7 @@ where
 #[cfg(test)]
 #[cfg(feature = "float")]
 mod tests {
-    use core::ops::{Index, IndexMut};
-    use minikalman_traits::matrix::{Matrix, MatrixMut};
+    use crate::test_dummies::{Dummy, DummyMatrix};
 
     use super::*;
 
@@ -729,12 +729,6 @@ mod tests {
 
         trait_impl(measurement);
     }
-
-    #[derive(Default)]
-    struct Dummy<T>(DummyMatrix<T>, PhantomData<T>);
-
-    #[derive(Default)]
-    struct DummyMatrix<T>(PhantomData<T>);
 
     impl<const STATES: usize, T> MeasurementVector<STATES, T> for Dummy<T> {
         type Target = DummyMatrix<T>;
@@ -885,33 +879,4 @@ mod tests {
             &mut self.0
         }
     }
-
-    impl<T> AsRef<[T]> for DummyMatrix<T> {
-        fn as_ref(&self) -> &[T] {
-            todo!()
-        }
-    }
-
-    impl<T> AsMut<[T]> for DummyMatrix<T> {
-        fn as_mut(&mut self) -> &mut [T] {
-            todo!()
-        }
-    }
-
-    impl<T> Index<usize> for DummyMatrix<T> {
-        type Output = T;
-
-        fn index(&self, _index: usize) -> &Self::Output {
-            todo!()
-        }
-    }
-
-    impl<T> IndexMut<usize> for DummyMatrix<T> {
-        fn index_mut(&mut self, _index: usize) -> &mut Self::Output {
-            todo!()
-        }
-    }
-
-    impl<const ROWS: usize, const COLS: usize, T> Matrix<ROWS, COLS, T> for DummyMatrix<T> {}
-    impl<const ROWS: usize, const COLS: usize, T> MatrixMut<ROWS, COLS, T> for DummyMatrix<T> {}
 }

--- a/crates/minikalman/src/static_macros.rs
+++ b/crates/minikalman/src/static_macros.rs
@@ -58,12 +58,12 @@ macro_rules! impl_buffer_x {
         $($keywords)* $vec_name: $crate::buffer_types::StateVectorBuffer<
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, 1, { $num_states * 1 }, $t>,
+            $crate::traits::matrix::MatrixDataArray<$num_states, 1, { $num_states * 1 }, $t>,
         > = $crate::buffer_types::StateVectorBuffer::<
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, 1, { $num_states * 1 }, $t>,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+            $crate::traits::matrix::MatrixDataArray<$num_states, 1, { $num_states * 1 }, $t>,
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_states * 1 }],
         ));
     };
@@ -128,12 +128,12 @@ macro_rules! impl_buffer_A {
         $($keywords)* $mat_name: $crate::buffer_types::SystemMatrixMutBuffer<
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, $num_states, { $num_states * $num_states }, $t>,
+            $crate::traits::matrix::MatrixDataArray<$num_states, $num_states, { $num_states * $num_states }, $t>,
         > = $crate::buffer_types::SystemMatrixMutBuffer::<
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, $num_states, { $num_states * $num_states }, $t>,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+            $crate::traits::matrix::MatrixDataArray<$num_states, $num_states, { $num_states * $num_states }, $t>,
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_states * $num_states }],
         ));
     };
@@ -187,12 +187,12 @@ macro_rules! impl_buffer_P {
         $($keywords)* $mat_name: $crate::buffer_types::SystemCovarianceMatrixBuffer<
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, $num_states, { $num_states * $num_states }, $t>,
+            $crate::traits::matrix::MatrixDataArray<$num_states, $num_states, { $num_states * $num_states }, $t>,
         > = $crate::buffer_types::SystemCovarianceMatrixBuffer::<
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, $num_states, { $num_states * $num_states }, $t>,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+            $crate::traits::matrix::MatrixDataArray<$num_states, $num_states, { $num_states * $num_states }, $t>,
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_states * $num_states }],
         ));
     };
@@ -245,12 +245,12 @@ macro_rules! impl_buffer_u {
         $($keywords)* $vec_name: $crate::buffer_types::InputVectorBuffer<
             $num_inputs,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_inputs, 1, { $num_inputs * 1 }, $t>,
+            $crate::traits::matrix::MatrixDataArray<$num_inputs, 1, { $num_inputs * 1 }, $t>,
         > = $crate::buffer_types::InputVectorBuffer::<
             $num_inputs,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_inputs, 1, { $num_inputs * 1 }, $t>,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+            $crate::traits::matrix::MatrixDataArray<$num_inputs, 1, { $num_inputs * 1 }, $t>,
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_inputs * 1 }],
         ));
     };
@@ -307,13 +307,13 @@ macro_rules! impl_buffer_B {
             $num_states,
             $num_inputs,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, $num_inputs, { $num_states * $num_inputs }, $t>,
+            $crate::traits::matrix::MatrixDataArray<$num_states, $num_inputs, { $num_states * $num_inputs }, $t>,
         > = $crate::buffer_types::InputMatrixMutBuffer::<
             $num_states,
             $num_inputs,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, $num_inputs, { $num_states * $num_inputs }, $t>,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+            $crate::traits::matrix::MatrixDataArray<$num_states, $num_inputs, { $num_states * $num_inputs }, $t>,
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_states * $num_inputs }],
         ));
     };
@@ -367,12 +367,12 @@ macro_rules! impl_buffer_Q {
         $($keywords)* $mat_name: $crate::buffer_types::InputCovarianceMatrixMutBuffer<
             $num_inputs,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_inputs, $num_inputs, { $num_inputs * $num_inputs }, $t>,
+            $crate::traits::matrix::MatrixDataArray<$num_inputs, $num_inputs, { $num_inputs * $num_inputs }, $t>,
         > = $crate::buffer_types::InputCovarianceMatrixMutBuffer::<
             $num_inputs,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_inputs, $num_inputs, { $num_inputs * $num_inputs }, $t>,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+            $crate::traits::matrix::MatrixDataArray<$num_inputs, $num_inputs, { $num_inputs * $num_inputs }, $t>,
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_inputs * $num_inputs }],
         ));
     };
@@ -425,12 +425,12 @@ macro_rules! impl_buffer_z {
         $($keywords)* $vec_name: $crate::buffer_types::MeasurementVectorBuffer<
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_measurements, 1, { $num_measurements * 1 }, $t>,
+            $crate::traits::matrix::MatrixDataArray<$num_measurements, 1, { $num_measurements * 1 }, $t>,
         > = $crate::buffer_types::MeasurementVectorBuffer::<
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_measurements, 1, { $num_measurements * 1 }, $t>,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+            $crate::traits::matrix::MatrixDataArray<$num_measurements, 1, { $num_measurements * 1 }, $t>,
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_measurements * 1 }],
         ));
     };
@@ -487,7 +487,7 @@ macro_rules! impl_buffer_H {
             $num_measurements,
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_measurements,
                 $num_states,
                 { $num_measurements * $num_states },
@@ -497,13 +497,13 @@ macro_rules! impl_buffer_H {
             $num_measurements,
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_measurements,
                 $num_states,
                 { $num_measurements * $num_states },
                 $t,
             >,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_measurements * $num_states }],
         ));
     };
@@ -557,7 +557,7 @@ macro_rules! impl_buffer_R {
         $($keywords)* $mat_name: $crate::buffer_types::MeasurementProcessNoiseCovarianceMatrixBuffer<
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_measurements,
                 $num_measurements,
                 { $num_measurements * $num_measurements },
@@ -566,13 +566,13 @@ macro_rules! impl_buffer_R {
         > = $crate::buffer_types::MeasurementProcessNoiseCovarianceMatrixBuffer::<
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_measurements,
                 $num_measurements,
                 { $num_measurements * $num_measurements },
                 $t,
             >,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_measurements * $num_measurements }],
         ));
     };
@@ -625,12 +625,12 @@ macro_rules! impl_buffer_y {
         $($keywords)* $vec_name: $crate::buffer_types::InnovationVectorBuffer<
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_measurements, 1, { $num_measurements * 1 }, $t>,
+            $crate::traits::matrix::MatrixDataArray<$num_measurements, 1, { $num_measurements * 1 }, $t>,
         > = $crate::buffer_types::InnovationVectorBuffer::<
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_measurements, 1, { $num_measurements * 1 }, $t>,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+            $crate::traits::matrix::MatrixDataArray<$num_measurements, 1, { $num_measurements * 1 }, $t>,
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_measurements * 1 }],
         ));
     };
@@ -684,7 +684,7 @@ macro_rules! impl_buffer_S {
         $($keywords)* $mat_name: $crate::buffer_types::InnovationResidualCovarianceMatrixBuffer<
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_measurements,
                 $num_measurements,
                 { $num_measurements * $num_measurements },
@@ -693,13 +693,13 @@ macro_rules! impl_buffer_S {
         > = $crate::buffer_types::InnovationResidualCovarianceMatrixBuffer::<
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_measurements,
                 $num_measurements,
                 { $num_measurements * $num_measurements },
                 $t,
             >,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_measurements * $num_measurements }],
         ));
     };
@@ -756,7 +756,7 @@ macro_rules! impl_buffer_K {
             $num_states,
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_states,
                 $num_measurements,
                 { $num_states * $num_measurements },
@@ -766,13 +766,13 @@ macro_rules! impl_buffer_K {
             $num_states,
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_states,
                 $num_measurements,
                 { $num_states * $num_measurements },
                 $t,
             >,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_states * $num_measurements }],
         ));
     };
@@ -780,7 +780,7 @@ macro_rules! impl_buffer_K {
 
 /// Creates a static buffer fitting the temporary x predictions (`num_states` × `1`).
 ///
-/// This will create a [`StatePredictionVectorBuffer`](crate::buffer_types::StatePredictionVectorBuffer)
+/// This will create a [`StatePredictionVectorBuffer`](crate::buffer_types::TemporaryStatePredictionVectorBuffer)
 /// backed by a [`MatrixDataOwned`](crate::MatrixDataOwned).
 ///
 /// ## Arguments
@@ -822,15 +822,15 @@ macro_rules! impl_buffer_temp_x {
         $crate::impl_buffer_temp_x!($vec_name, $num_states, $t, $init, static)
     };
     ($vec_name:ident, $num_states:expr, $t:ty, $init:expr, $($keywords:tt)+) => {
-        $($keywords)* $vec_name: $crate::buffer_types::StatePredictionVectorBuffer<
+        $($keywords)* $vec_name: $crate::buffer_types::TemporaryStatePredictionVectorBuffer<
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, 1, { $num_states * 1 }, $t>,
-        > = $crate::buffer_types::StatePredictionVectorBuffer::<
+            $crate::traits::matrix::MatrixDataArray<$num_states, 1, { $num_states * 1 }, $t>,
+        > = $crate::buffer_types::TemporaryStatePredictionVectorBuffer::<
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, 1, { $num_states * 1 }, $t>,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+            $crate::traits::matrix::MatrixDataArray<$num_states, 1, { $num_states * 1 }, $t>,
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_states * 1 }],
         ));
     };
@@ -884,12 +884,12 @@ macro_rules! impl_buffer_temp_P {
         $($keywords)* $mat_name: $crate::buffer_types::TemporaryStateMatrixBuffer<
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, $num_states, { $num_states * $num_states }, $t>,
+            $crate::traits::matrix::MatrixDataArray<$num_states, $num_states, { $num_states * $num_states }, $t>,
         > = $crate::buffer_types::TemporaryStateMatrixBuffer::<
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, $num_states, { $num_states * $num_states }, $t>,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+            $crate::traits::matrix::MatrixDataArray<$num_states, $num_states, { $num_states * $num_states }, $t>,
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_states * $num_states }],
         ));
     };
@@ -946,13 +946,13 @@ macro_rules! impl_buffer_temp_BQ {
             $num_states,
             $num_inputs,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, $num_inputs, { $num_states * $num_inputs }, $t>,
+            $crate::traits::matrix::MatrixDataArray<$num_states, $num_inputs, { $num_states * $num_inputs }, $t>,
         > = $crate::buffer_types::TemporaryBQMatrixBuffer::<
             $num_states,
             $num_inputs,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, $num_inputs, { $num_states * $num_inputs }, $t>,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+            $crate::traits::matrix::MatrixDataArray<$num_states, $num_inputs, { $num_states * $num_inputs }, $t>,
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_states * $num_inputs }],
         ));
     };
@@ -1006,7 +1006,7 @@ macro_rules! impl_buffer_temp_S_inv {
         $($keywords)* $mat_name: $crate::buffer_types::TemporaryResidualCovarianceInvertedMatrixBuffer<
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_measurements,
                 $num_measurements,
                 { $num_measurements * $num_measurements },
@@ -1015,13 +1015,13 @@ macro_rules! impl_buffer_temp_S_inv {
         > = $crate::buffer_types::TemporaryResidualCovarianceInvertedMatrixBuffer::<
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_measurements,
                 $num_measurements,
                 { $num_measurements * $num_measurements },
                 $t,
             >,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_measurements * $num_measurements }],
         ));
     };
@@ -1078,7 +1078,7 @@ macro_rules! impl_buffer_temp_HP {
             $num_measurements,
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_measurements,
                 $num_states,
                 { $num_measurements * $num_states },
@@ -1088,13 +1088,13 @@ macro_rules! impl_buffer_temp_HP {
             $num_measurements,
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_measurements,
                 $num_states,
                 { $num_measurements * $num_states },
                 $t,
             >,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_measurements * $num_states }],
         ));
     };
@@ -1151,7 +1151,7 @@ macro_rules! impl_buffer_temp_PHt {
             $num_states,
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_states,
                 $num_measurements,
                 { $num_states * $num_measurements },
@@ -1161,13 +1161,13 @@ macro_rules! impl_buffer_temp_PHt {
             $num_states,
             $num_measurements,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<
+            $crate::traits::matrix::MatrixDataArray<
                 $num_states,
                 $num_measurements,
                 { $num_states * $num_measurements },
                 $t,
             >,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_states * $num_measurements }],
         ));
     };
@@ -1221,12 +1221,12 @@ macro_rules! impl_buffer_temp_KHP {
         $($keywords)* $mat_name: $crate::buffer_types::TemporaryKHPMatrixBuffer<
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, $num_states, { $num_states * $num_states }, $t>,
+            $crate::traits::matrix::MatrixDataArray<$num_states, $num_states, { $num_states * $num_states }, $t>,
         > = $crate::buffer_types::TemporaryKHPMatrixBuffer::<
             $num_states,
             $t,
-            $crate::traits::matrix::MatrixDataOwned<$num_states, $num_states, { $num_states * $num_states }, $t>,
-        >::new($crate::traits::matrix::MatrixDataOwned::new_unchecked(
+            $crate::traits::matrix::MatrixDataArray<$num_states, $num_states, { $num_states * $num_states }, $t>,
+        >::new($crate::traits::matrix::MatrixDataArray::new_unchecked(
             [$init; { $num_states * $num_states }],
         ));
     };

--- a/crates/minikalman/src/test_dummies.rs
+++ b/crates/minikalman/src/test_dummies.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(coverage_nightly, coverage(off))]
+
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};

--- a/crates/minikalman/src/test_dummies.rs
+++ b/crates/minikalman/src/test_dummies.rs
@@ -1,0 +1,67 @@
+use minikalman_traits::matrix::{Matrix, MatrixMut};
+use std::marker::PhantomData;
+use std::ops::{Index, IndexMut};
+
+/// A dummy buffer type that holds a [`DummyMatrix`]
+#[derive(Default)]
+pub struct Dummy<T>(pub DummyMatrix<T>, PhantomData<T>);
+
+/// A dummy matrix that is arbitrarily shaped.
+#[derive(Default)]
+pub struct DummyMatrix<T>(PhantomData<T>);
+
+impl<T> AsRef<[T]> for Dummy<T> {
+    fn as_ref(&self) -> &[T] {
+        self.0.as_ref()
+    }
+}
+
+impl<T> AsMut<[T]> for Dummy<T> {
+    fn as_mut(&mut self) -> &mut [T] {
+        self.0.as_mut()
+    }
+}
+
+impl<T> Index<usize> for Dummy<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.0.index(index)
+    }
+}
+
+impl<T> IndexMut<usize> for Dummy<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        self.0.index_mut(index)
+    }
+}
+
+impl<T> AsRef<[T]> for DummyMatrix<T> {
+    fn as_ref(&self) -> &[T] {
+        unimplemented!("A dummy matrix cannot actually dereference into data")
+    }
+}
+
+impl<T> AsMut<[T]> for DummyMatrix<T> {
+    fn as_mut(&mut self) -> &mut [T] {
+        unimplemented!("A dummy matrix cannot actually dereference into data")
+    }
+}
+
+impl<T> Index<usize> for DummyMatrix<T> {
+    type Output = T;
+
+    fn index(&self, _index: usize) -> &Self::Output {
+        unimplemented!("A dummy matrix cannot actually index into data")
+    }
+}
+
+impl<T> IndexMut<usize> for DummyMatrix<T> {
+    fn index_mut(&mut self, _index: usize) -> &mut Self::Output {
+        unimplemented!("A dummy matrix cannot actually index into data")
+    }
+}
+
+impl<const ROWS: usize, const COLS: usize, T> Matrix<ROWS, COLS, T> for DummyMatrix<T> {}
+
+impl<const ROWS: usize, const COLS: usize, T> MatrixMut<ROWS, COLS, T> for DummyMatrix<T> {}

--- a/crates/minikalman/src/test_dummies.rs
+++ b/crates/minikalman/src/test_dummies.rs
@@ -1,6 +1,6 @@
+use core::marker::PhantomData;
+use core::ops::{Index, IndexMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};
-use std::marker::PhantomData;
-use std::ops::{Index, IndexMut};
 
 /// A dummy buffer type that holds a [`DummyMatrix`]
 #[derive(Default)]

--- a/crates/minikalman/src/test_dummies.rs
+++ b/crates/minikalman/src/test_dummies.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(coverage_nightly, coverage(off))]
-
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use minikalman_traits::matrix::{Matrix, MatrixMut};

--- a/crates/minikalman/tests/gravity.rs
+++ b/crates/minikalman/tests/gravity.rs
@@ -110,7 +110,7 @@ fn test_gravity_estimation() {
 }
 
 /// Initializes the state vector with initial assumptions.
-fn initialize_state_vector(filter: &mut impl StateVector<NUM_STATES, f32>) {
+fn initialize_state_vector(filter: &mut impl StateVectorMut<NUM_STATES, f32>) {
     filter.apply(|state| {
         state[0] = 0 as _; // position
         state[1] = 0 as _; // velocity

--- a/crates/minikalman/tests/gravity.rs
+++ b/crates/minikalman/tests/gravity.rs
@@ -4,7 +4,6 @@
 //! under earth conditions (i.e. a ≈ 9.807 m/s²) through position observations only.
 
 #![forbid(unsafe_code)]
-#![cfg(feature = "float")]
 
 use minikalman::prelude::*;
 use minikalman_traits::matrix::MatrixMut;

--- a/crates/minikalman/tests/gravity_q_tuned.rs
+++ b/crates/minikalman/tests/gravity_q_tuned.rs
@@ -112,7 +112,7 @@ fn test_gravity_estimation_tuned() {
 }
 
 /// Initializes the state vector with initial assumptions.
-fn initialize_state_vector(filter: &mut impl StateVector<NUM_STATES, f64>) {
+fn initialize_state_vector(filter: &mut impl StateVectorMut<NUM_STATES, f64>) {
     filter.apply(|state| {
         state[0] = 0 as _; // position
         state[1] = 0 as _; // velocity

--- a/crates/minikalman/tests/gravity_q_tuned.rs
+++ b/crates/minikalman/tests/gravity_q_tuned.rs
@@ -4,7 +4,6 @@
 //! under earth conditions (i.e. a ≈ 9.807 m/s²) through position observations only.
 
 #![forbid(unsafe_code)]
-#![cfg(feature = "float")]
 
 use minikalman::prelude::*;
 use minikalman_traits::matrix::MatrixMut;

--- a/xbuild-tests/stm32/Cargo.toml
+++ b/xbuild-tests/stm32/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [features]
 default = ["kalman-fixed", "kalman-float"]
-kalman-float = ["minikalman/float", "minikalman/libm"]
+kalman-float = ["minikalman/libm"]
 kalman-fixed = ["minikalman/fixed"]
 
 [dependencies]

--- a/xbuild-tests/stm32/src/kalman_fixed_example.rs
+++ b/xbuild-tests/stm32/src/kalman_fixed_example.rs
@@ -119,7 +119,7 @@ pub fn predict_gravity() -> I16F16 {
         SystemMatrixMutBuffer::from(unsafe { gravity_A.as_mut() }),
         StateVectorBuffer::from(unsafe { gravity_x.as_mut() }),
         SystemCovarianceMatrixBuffer::from(unsafe { gravity_P.as_mut() }),
-        StatePredictionVectorBuffer::from(unsafe { gravity_temp_x.as_mut() }),
+        TemporaryStatePredictionVectorBuffer::from(unsafe { gravity_temp_x.as_mut() }),
         TemporaryStateMatrixBuffer::from(unsafe { gravity_temp_P.as_mut() }),
     );
 
@@ -165,7 +165,7 @@ pub fn predict_gravity() -> I16F16 {
 }
 
 /// Initializes the state vector with initial assumptions.
-fn initialize_state_vector(filter: &mut impl StateVector<NUM_STATES, I16F16>) {
+fn initialize_state_vector(filter: &mut impl StateVectorMut<NUM_STATES, I16F16>) {
     filter.apply(|state| {
         state[0] = I16F16::ZERO; // position
         state[1] = I16F16::ZERO; // velocity

--- a/xbuild-tests/stm32/src/kalman_float_example.rs
+++ b/xbuild-tests/stm32/src/kalman_float_example.rs
@@ -59,7 +59,7 @@ pub fn predict_gravity() -> f32 {
         SystemMatrixMutBuffer::from(unsafe { gravity_A.as_mut() }),
         StateVectorBuffer::from(unsafe { gravity_x.as_mut() }),
         SystemCovarianceMatrixBuffer::from(unsafe { gravity_P.as_mut() }),
-        StatePredictionVectorBuffer::from(unsafe { gravity_temp_x.as_mut() }),
+        TemporaryStatePredictionVectorBuffer::from(unsafe { gravity_temp_x.as_mut() }),
         TemporaryStateMatrixBuffer::from(unsafe { gravity_temp_P.as_mut() }),
     );
 
@@ -105,7 +105,7 @@ pub fn predict_gravity() -> f32 {
 }
 
 /// Initializes the state vector with initial assumptions.
-fn initialize_state_vector(filter: &mut impl StateVector<NUM_STATES, f32>) {
+fn initialize_state_vector(filter: &mut impl StateVectorMut<NUM_STATES, f32>) {
     filter.apply(|state| {
         state[0] = 0.0; // position
         state[1] = 0.0; // velocity


### PR DESCRIPTION
This adds builders to quickly conjure a filter when the `alloc` crate feature is enabled. This turns the lengthy buffer wiring into a simple

```rust
let builder = KalmanFilterBuilder::<NUM_STATES, f32>::default();
let mut filter = builder.build();
let mut input = builder.inputs().build::<NUM_INPUTS>();
let mut measurement = builder.measurements().build::<NUM_MEASUREMENTS>();
```

These returned types still require the temporary buffers. While this works for this specific crate, it would be nice if we could just keep it to the strictly necessary definitions (i.e., no temp buffers in the type signature).