### PR TITLE
Simplify trait bounds and add inspection functions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Generate code coverage
-        run: cargo llvm-cov nextest --features=std,fixed --package minikalman --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --features=std,fixed,alloc --package minikalman --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:

--- a/crates/minikalman/benches/gravity.rs
+++ b/crates/minikalman/benches/gravity.rs
@@ -76,7 +76,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         initialize_state_transition_matrix(filter.state_transition_mut());
         initialize_state_covariance_matrix(filter.estimate_covariance_mut());
         initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-        initialize_position_measurement_process_noise_matrix(measurement.process_noise_mut());
+        initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
 
         bencher.iter(|| {
             for t in 0..REAL_DISTANCE.len() {
@@ -116,7 +116,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         initialize_state_transition_matrix(filter.state_transition_mut());
         initialize_state_covariance_matrix(filter.estimate_covariance_mut());
         initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-        initialize_position_measurement_process_noise_matrix(measurement.process_noise_mut());
+        initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
 
         bencher.iter(|| {
             filter.predict();
@@ -150,7 +150,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         initialize_state_transition_matrix(filter.state_transition_mut());
         initialize_state_covariance_matrix(filter.estimate_covariance_mut());
         initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-        initialize_position_measurement_process_noise_matrix(measurement.process_noise_mut());
+        initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
 
         measurement.measurement_vector_apply(|z| {
             z[0] = black_box(REAL_DISTANCE[0]) + black_box(OBSERVATION_ERROR[0])

--- a/crates/minikalman/benches/gravity.rs
+++ b/crates/minikalman/benches/gravity.rs
@@ -76,7 +76,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         initialize_state_transition_matrix(filter.state_transition_mut());
         initialize_state_covariance_matrix(filter.estimate_covariance_mut());
         initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-        initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
+        initialize_position_measurement_process_noise_matrix(
+            measurement.measurement_noise_covariance_mut(),
+        );
 
         bencher.iter(|| {
             for t in 0..REAL_DISTANCE.len() {
@@ -116,7 +118,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         initialize_state_transition_matrix(filter.state_transition_mut());
         initialize_state_covariance_matrix(filter.estimate_covariance_mut());
         initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-        initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
+        initialize_position_measurement_process_noise_matrix(
+            measurement.measurement_noise_covariance_mut(),
+        );
 
         bencher.iter(|| {
             filter.predict();
@@ -150,7 +154,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         initialize_state_transition_matrix(filter.state_transition_mut());
         initialize_state_covariance_matrix(filter.estimate_covariance_mut());
         initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-        initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
+        initialize_position_measurement_process_noise_matrix(
+            measurement.measurement_noise_covariance_mut(),
+        );
 
         measurement.measurement_vector_apply(|z| {
             z[0] = black_box(REAL_DISTANCE[0]) + black_box(OBSERVATION_ERROR[0])

--- a/crates/minikalman/benches/gravity.rs
+++ b/crates/minikalman/benches/gravity.rs
@@ -21,35 +21,33 @@ const NUM_OBSERVATIONS: usize = 1;
 #[allow(non_snake_case)]
 fn criterion_benchmark(c: &mut Criterion) {
     // System buffers.
-    let mut gravity_x = BufferBuilder::state_vector_x::<NUM_STATES>().new(0.0_f32);
-    let mut gravity_A = BufferBuilder::system_matrix_A::<NUM_STATES>().new(0.0_f32);
-    let mut gravity_P = BufferBuilder::estimate_covariance_P::<NUM_STATES>().new(0.0_f32);
+    let mut gravity_x = BufferBuilder::state_vector_x::<NUM_STATES>().new();
+    let mut gravity_A = BufferBuilder::system_matrix_A::<NUM_STATES>().new();
+    let mut gravity_P = BufferBuilder::estimate_covariance_P::<NUM_STATES>().new();
 
     // Control buffers.
-    // let mut gravity_u = BufferBuilder::control_vector_u::<NUM_CONTROLS>().new(0.0_f32);
-    // let mut gravity_B = BufferBuilder::control_matrix_B::<NUM_STATES, NUM_CONTROLS>().new(0.0_f32);
-    // let mut gravity_Q = BufferBuilder::control_covariance_Q::<NUM_CONTROLS>().new(0.0_f32);
+    // let mut gravity_u = BufferBuilder::control_vector_u::<NUM_CONTROLS>().new();
+    // let mut gravity_B = BufferBuilder::control_matrix_B::<NUM_STATES, NUM_CONTROLS>().new();
+    // let mut gravity_Q = BufferBuilder::control_covariance_Q::<NUM_CONTROLS>().new();
 
     // Observation buffers.
-    let mut gravity_z = BufferBuilder::measurement_vector_z::<NUM_OBSERVATIONS>().new(0.0_f32);
-    let mut gravity_H =
-        BufferBuilder::observation_matrix_H::<NUM_OBSERVATIONS, NUM_STATES>().new(0.0_f32);
-    let mut gravity_R = BufferBuilder::observation_covariance_R::<NUM_OBSERVATIONS>().new(0.0_f32);
-    let mut gravity_y = BufferBuilder::innovation_vector_y::<NUM_OBSERVATIONS>().new(0.0_f32);
-    let mut gravity_S = BufferBuilder::innovation_covariance_S::<NUM_OBSERVATIONS>().new(0.0_f32);
-    let mut gravity_K = BufferBuilder::kalman_gain_K::<NUM_STATES, NUM_OBSERVATIONS>().new(0.0_f32);
+    let mut gravity_z = BufferBuilder::measurement_vector_z::<NUM_OBSERVATIONS>().new();
+    let mut gravity_H = BufferBuilder::observation_matrix_H::<NUM_OBSERVATIONS, NUM_STATES>().new();
+    let mut gravity_R = BufferBuilder::observation_covariance_R::<NUM_OBSERVATIONS>().new();
+    let mut gravity_y = BufferBuilder::innovation_vector_y::<NUM_OBSERVATIONS>().new();
+    let mut gravity_S = BufferBuilder::innovation_covariance_S::<NUM_OBSERVATIONS>().new();
+    let mut gravity_K = BufferBuilder::kalman_gain_K::<NUM_STATES, NUM_OBSERVATIONS>().new();
 
     // Filter temporaries.
-    let mut gravity_temp_x = BufferBuilder::state_prediction_temp_x::<NUM_STATES>().new(0.0_f32);
-    let mut gravity_temp_P = BufferBuilder::temp_system_covariance_P::<NUM_STATES>().new(0.0_f32);
-    // let mut gravity_temp_BQ = BufferBuilder::temp_BQ::<NUM_STATES, NUM_CONTROLS>().new(0.0_f32);
+    let mut gravity_temp_x = BufferBuilder::state_prediction_temp_x::<NUM_STATES>().new();
+    let mut gravity_temp_P = BufferBuilder::temp_system_covariance_P::<NUM_STATES>().new();
+    // let mut gravity_temp_BQ = BufferBuilder::temp_BQ::<NUM_STATES, NUM_CONTROLS>().new();
 
     // Observation temporaries.
-    let mut gravity_temp_S_inv = BufferBuilder::temp_S_inv::<NUM_OBSERVATIONS>().new(0.0_f32);
-    let mut gravity_temp_HP = BufferBuilder::temp_HP::<NUM_OBSERVATIONS, NUM_STATES>().new(0.0_f32);
-    let mut gravity_temp_PHt =
-        BufferBuilder::temp_PHt::<NUM_STATES, NUM_OBSERVATIONS>().new(0.0_f32);
-    let mut gravity_temp_KHP = BufferBuilder::temp_KHP::<NUM_STATES>().new(0.0_f32);
+    let mut gravity_temp_S_inv = BufferBuilder::temp_S_inv::<NUM_OBSERVATIONS>().new();
+    let mut gravity_temp_HP = BufferBuilder::temp_HP::<NUM_OBSERVATIONS, NUM_STATES>().new();
+    let mut gravity_temp_PHt = BufferBuilder::temp_PHt::<NUM_STATES, NUM_OBSERVATIONS>().new();
+    let mut gravity_temp_KHP = BufferBuilder::temp_KHP::<NUM_STATES>().new();
 
     c.bench_function("filter loop", |bencher| {
         let mut filter = KalmanBuilder::new::<NUM_STATES, f32>(

--- a/crates/minikalman/benches/gravity_fixed.rs
+++ b/crates/minikalman/benches/gravity_fixed.rs
@@ -61,35 +61,27 @@ const NUM_OBSERVATIONS: usize = 1;
 #[allow(non_snake_case)]
 fn criterion_benchmark(c: &mut Criterion) {
     // System buffers.
-    let mut gravity_x = BufferBuilder::state_vector_x::<NUM_STATES>().new(I16F16::ZERO);
-    let mut gravity_A = BufferBuilder::system_matrix_A::<NUM_STATES>().new(I16F16::ZERO);
-    let mut gravity_P = BufferBuilder::estimate_covariance_P::<NUM_STATES>().new(I16F16::ZERO);
+    let mut gravity_x = BufferBuilder::state_vector_x::<NUM_STATES>().new();
+    let mut gravity_A = BufferBuilder::system_matrix_A::<NUM_STATES>().new();
+    let mut gravity_P = BufferBuilder::estimate_covariance_P::<NUM_STATES>().new();
 
     // Observation buffers.
-    let mut gravity_z = BufferBuilder::measurement_vector_z::<NUM_OBSERVATIONS>().new(I16F16::ZERO);
-    let mut gravity_H =
-        BufferBuilder::observation_matrix_H::<NUM_OBSERVATIONS, NUM_STATES>().new(I16F16::ZERO);
-    let mut gravity_R =
-        BufferBuilder::observation_covariance_R::<NUM_OBSERVATIONS>().new(I16F16::ZERO);
-    let mut gravity_y = BufferBuilder::innovation_vector_y::<NUM_OBSERVATIONS>().new(I16F16::ZERO);
-    let mut gravity_S =
-        BufferBuilder::innovation_covariance_S::<NUM_OBSERVATIONS>().new(I16F16::ZERO);
-    let mut gravity_K =
-        BufferBuilder::kalman_gain_K::<NUM_STATES, NUM_OBSERVATIONS>().new(I16F16::ZERO);
+    let mut gravity_z = BufferBuilder::measurement_vector_z::<NUM_OBSERVATIONS>().new();
+    let mut gravity_H = BufferBuilder::observation_matrix_H::<NUM_OBSERVATIONS, NUM_STATES>().new();
+    let mut gravity_R = BufferBuilder::observation_covariance_R::<NUM_OBSERVATIONS>().new();
+    let mut gravity_y = BufferBuilder::innovation_vector_y::<NUM_OBSERVATIONS>().new();
+    let mut gravity_S = BufferBuilder::innovation_covariance_S::<NUM_OBSERVATIONS>().new();
+    let mut gravity_K = BufferBuilder::kalman_gain_K::<NUM_STATES, NUM_OBSERVATIONS>().new();
 
     // Filter temporaries.
-    let mut gravity_temp_x =
-        BufferBuilder::state_prediction_temp_x::<NUM_STATES>().new(I16F16::ZERO);
-    let mut gravity_temp_P =
-        BufferBuilder::temp_system_covariance_P::<NUM_STATES>().new(I16F16::ZERO);
+    let mut gravity_temp_x = BufferBuilder::state_prediction_temp_x::<NUM_STATES>().new();
+    let mut gravity_temp_P = BufferBuilder::temp_system_covariance_P::<NUM_STATES>().new();
 
     // Observation temporaries.
-    let mut gravity_temp_S_inv = BufferBuilder::temp_S_inv::<NUM_OBSERVATIONS>().new(I16F16::ZERO);
-    let mut gravity_temp_HP =
-        BufferBuilder::temp_HP::<NUM_OBSERVATIONS, NUM_STATES>().new(I16F16::ZERO);
-    let mut gravity_temp_PHt =
-        BufferBuilder::temp_PHt::<NUM_STATES, NUM_OBSERVATIONS>().new(I16F16::ZERO);
-    let mut gravity_temp_KHP = BufferBuilder::temp_KHP::<NUM_STATES>().new(I16F16::ZERO);
+    let mut gravity_temp_S_inv = BufferBuilder::temp_S_inv::<NUM_OBSERVATIONS>().new();
+    let mut gravity_temp_HP = BufferBuilder::temp_HP::<NUM_OBSERVATIONS, NUM_STATES>().new();
+    let mut gravity_temp_PHt = BufferBuilder::temp_PHt::<NUM_STATES, NUM_OBSERVATIONS>().new();
+    let mut gravity_temp_KHP = BufferBuilder::temp_KHP::<NUM_STATES>().new();
 
     c.bench_function("filter loop (fixed-point)", |bencher| {
         let mut filter = KalmanBuilder::new::<NUM_STATES, I16F16>(

--- a/crates/minikalman/benches/gravity_fixed.rs
+++ b/crates/minikalman/benches/gravity_fixed.rs
@@ -110,7 +110,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         initialize_state_transition_matrix(filter.state_transition_mut());
         initialize_state_covariance_matrix(filter.estimate_covariance_mut());
         initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-        initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
+        initialize_position_measurement_process_noise_matrix(
+            measurement.measurement_noise_covariance_mut(),
+        );
 
         bencher.iter(|| {
             for t in 0..REAL_DISTANCE.len() {
@@ -150,7 +152,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         initialize_state_transition_matrix(filter.state_transition_mut());
         initialize_state_covariance_matrix(filter.estimate_covariance_mut());
         initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-        initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
+        initialize_position_measurement_process_noise_matrix(
+            measurement.measurement_noise_covariance_mut(),
+        );
 
         bencher.iter(|| {
             filter.predict();
@@ -184,7 +188,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         initialize_state_transition_matrix(filter.state_transition_mut());
         initialize_state_covariance_matrix(filter.estimate_covariance_mut());
         initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-        initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
+        initialize_position_measurement_process_noise_matrix(
+            measurement.measurement_noise_covariance_mut(),
+        );
 
         measurement.measurement_vector_apply(|z| {
             z[0] = black_box(REAL_DISTANCE[0]) + black_box(OBSERVATION_ERROR[0])

--- a/crates/minikalman/benches/gravity_fixed.rs
+++ b/crates/minikalman/benches/gravity_fixed.rs
@@ -110,7 +110,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         initialize_state_transition_matrix(filter.state_transition_mut());
         initialize_state_covariance_matrix(filter.estimate_covariance_mut());
         initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-        initialize_position_measurement_process_noise_matrix(measurement.process_noise_mut());
+        initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
 
         bencher.iter(|| {
             for t in 0..REAL_DISTANCE.len() {
@@ -150,7 +150,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         initialize_state_transition_matrix(filter.state_transition_mut());
         initialize_state_covariance_matrix(filter.estimate_covariance_mut());
         initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-        initialize_position_measurement_process_noise_matrix(measurement.process_noise_mut());
+        initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
 
         bencher.iter(|| {
             filter.predict();
@@ -184,7 +184,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         initialize_state_transition_matrix(filter.state_transition_mut());
         initialize_state_covariance_matrix(filter.estimate_covariance_mut());
         initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-        initialize_position_measurement_process_noise_matrix(measurement.process_noise_mut());
+        initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
 
         measurement.measurement_vector_apply(|z| {
             z[0] = black_box(REAL_DISTANCE[0]) + black_box(OBSERVATION_ERROR[0])

--- a/crates/minikalman/examples/car_2d.rs
+++ b/crates/minikalman/examples/car_2d.rs
@@ -71,7 +71,7 @@ fn main() {
     });
 
     // Set up the process noise covariance matrix as an identity matrix.
-    measurement.measurement_noise_apply(|mat| {
+    measurement.measurement_noise_covariance_apply(|mat| {
         mat.make_scalar(0.1);
     });
 

--- a/crates/minikalman/examples/car_2d.rs
+++ b/crates/minikalman/examples/car_2d.rs
@@ -59,13 +59,19 @@ fn main() {
         mat.set(2, 0, DELTA_T); // affect acceleration directly
     });
 
+    // Control vector is empty.
+    control.control_vector_mut().set_zero();
+
+    // Process noise covariance is identity.
+    control.process_noise_covariance_mut().make_identity();
+
     // Set up the observation matrix.
     measurement.observation_matrix_apply(|mat| {
         mat.set(0, 0, 1.0); // only the first element is set.
     });
 
     // Set up the process noise covariance matrix as an identity matrix.
-    measurement.process_noise_apply(|mat| {
+    measurement.measurement_noise_apply(|mat| {
         mat.make_scalar(0.1);
     });
 

--- a/crates/minikalman/examples/gravity.rs
+++ b/crates/minikalman/examples/gravity.rs
@@ -37,7 +37,9 @@ fn main() {
 
     // Set up measurements.
     initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-    initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
+    initialize_position_measurement_process_noise_matrix(
+        measurement.measurement_noise_covariance_mut(),
+    );
 
     // Generate the data.
     let measurements = generate_values(100);

--- a/crates/minikalman/examples/gravity.rs
+++ b/crates/minikalman/examples/gravity.rs
@@ -37,7 +37,7 @@ fn main() {
 
     // Set up measurements.
     initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-    initialize_position_measurement_process_noise_matrix(measurement.process_noise_mut());
+    initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
 
     // Generate the data.
     let measurements = generate_values(100);

--- a/crates/minikalman/examples/gravity_fixed.rs
+++ b/crates/minikalman/examples/gravity_fixed.rs
@@ -78,7 +78,7 @@ fn main() {
     initialize_state_transition_matrix(filter.state_transition_mut());
     initialize_state_covariance_matrix(filter.estimate_covariance_mut());
     initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-    initialize_position_measurement_process_noise_matrix(measurement.process_noise_mut());
+    initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
 
     // Filter!
     for t in 0..REAL_DISTANCE.len() {

--- a/crates/minikalman/examples/gravity_fixed.rs
+++ b/crates/minikalman/examples/gravity_fixed.rs
@@ -78,7 +78,9 @@ fn main() {
     initialize_state_transition_matrix(filter.state_transition_mut());
     initialize_state_covariance_matrix(filter.estimate_covariance_mut());
     initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-    initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
+    initialize_position_measurement_process_noise_matrix(
+        measurement.measurement_noise_covariance_mut(),
+    );
 
     // Filter!
     for t in 0..REAL_DISTANCE.len() {

--- a/crates/minikalman/src/buffers/builder.rs
+++ b/crates/minikalman/src/buffers/builder.rs
@@ -190,7 +190,7 @@ impl<const STATES: usize> StateVectorBufferBuilder<STATES> {
     /// use minikalman::buffers::types::StateVectorBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::state_vector_x::<3>().new(0.0);
+    /// let buffer = BufferBuilder::state_vector_x::<3>().new();
     ///
     /// let buffer: StateVectorBuffer<3, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 3);
@@ -198,7 +198,29 @@ impl<const STATES: usize> StateVectorBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> StateVectorBufferOwnedType<STATES, T>
+    pub fn new<T>(&self) -> StateVectorBufferOwnedType<STATES, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`StateVectorBufferBuilder`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::StateVectorBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::state_vector_x::<3>().new_with(0.0);
+    ///
+    /// let buffer: StateVectorBuffer<3, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 3);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> StateVectorBufferOwnedType<STATES, T>
     where
         T: Copy,
     {
@@ -221,7 +243,7 @@ impl<const STATES: usize> StateTransitionMatrixBufferBuilder<STATES> {
     /// use minikalman::BufferBuilder;
     /// use minikalman::buffers::types::StateTransitionMatrixMutBuffer;
     ///
-    /// let buffer  = BufferBuilder::system_matrix_A::<3>().new(0.0);
+    /// let buffer  = BufferBuilder::system_matrix_A::<3>().new();
     ///
     /// let buffer: StateTransitionMatrixMutBuffer<3, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 9);
@@ -229,7 +251,29 @@ impl<const STATES: usize> StateTransitionMatrixBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> SystemMatrixMutBufferOwnedType<STATES, T>
+    pub fn new<T>(&self) -> SystemMatrixMutBufferOwnedType<STATES, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`StateTransitionMatrixMutBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::BufferBuilder;
+    /// use minikalman::buffers::types::StateTransitionMatrixMutBuffer;
+    ///
+    /// let buffer  = BufferBuilder::system_matrix_A::<3>().new_with(0.0);
+    ///
+    /// let buffer: StateTransitionMatrixMutBuffer<3, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 9);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> SystemMatrixMutBufferOwnedType<STATES, T>
     where
         T: Copy,
     {
@@ -253,7 +297,7 @@ impl<const STATES: usize> EstimateCovarianceMatrixBufferBuilder<STATES> {
     /// use minikalman::buffers::types::EstimateCovarianceMatrixBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::estimate_covariance_P::<3>().new(0.0);
+    /// let buffer = BufferBuilder::estimate_covariance_P::<3>().new();
     ///
     /// let buffer: EstimateCovarianceMatrixBuffer<3, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 9);
@@ -261,7 +305,29 @@ impl<const STATES: usize> EstimateCovarianceMatrixBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> EstimateCovarianceMatrixBufferOwnedType<STATES, T>
+    pub fn new<T>(&self) -> EstimateCovarianceMatrixBufferOwnedType<STATES, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`EstimateCovarianceMatrixBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::EstimateCovarianceMatrixBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::estimate_covariance_P::<3>().new_with(0.0);
+    ///
+    /// let buffer: EstimateCovarianceMatrixBuffer<3, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 9);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> EstimateCovarianceMatrixBufferOwnedType<STATES, T>
     where
         T: Copy,
     {
@@ -284,7 +350,7 @@ impl<const CONTROLS: usize> ControlVectorBufferBuilder<CONTROLS> {
     /// use minikalman::buffers::types::ControlVectorBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::control_vector_u::<2>().new(0.0);
+    /// let buffer = BufferBuilder::control_vector_u::<2>().new();
     ///
     /// let buffer: ControlVectorBuffer<2, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 2);
@@ -293,6 +359,30 @@ impl<const CONTROLS: usize> ControlVectorBufferBuilder<CONTROLS> {
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
     pub fn new<T>(
+        &self,
+    ) -> ControlVectorBuffer<CONTROLS, T, MatrixDataArray<CONTROLS, 1, CONTROLS, T>>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`ControlVectorBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::ControlVectorBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::control_vector_u::<2>().new_with(0.0);
+    ///
+    /// let buffer: ControlVectorBuffer<2, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 2);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(
         &self,
         init: T,
     ) -> ControlVectorBuffer<CONTROLS, T, MatrixDataArray<CONTROLS, 1, CONTROLS, T>>
@@ -320,7 +410,7 @@ impl<const STATES: usize, const CONTROLS: usize>
     /// use minikalman::buffers::types::ControlMatrixMutBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer  = BufferBuilder::control_matrix_B::<3, 2>().new(0.0);
+    /// let buffer  = BufferBuilder::control_matrix_B::<3, 2>().new();
     ///
     /// let buffer: ControlMatrixMutBuffer<3, 2, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 6);
@@ -329,6 +419,30 @@ impl<const STATES: usize, const CONTROLS: usize>
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
     pub fn new<T>(
+        &self,
+    ) -> ControlMatrixMutBuffer<STATES, CONTROLS, T, MatrixDataBoxed<STATES, CONTROLS, T>>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`ControlMatrixMutBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::ControlMatrixMutBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer  = BufferBuilder::control_matrix_B::<3, 2>().new_with(0.0);
+    ///
+    /// let buffer: ControlMatrixMutBuffer<3, 2, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 6);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(
         &self,
         init: T,
     ) -> ControlMatrixMutBuffer<STATES, CONTROLS, T, MatrixDataBoxed<STATES, CONTROLS, T>>
@@ -354,7 +468,7 @@ impl<const CONTROLS: usize> ProcessNoiseCovarianceMatrixBufferBuilder<CONTROLS> 
     /// use minikalman::buffers::types::ProcessNoiseCovarianceMatrixMutBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer  = BufferBuilder::process_noise_covariance_Q::<2>().new(0.0);
+    /// let buffer  = BufferBuilder::process_noise_covariance_Q::<2>().new();
     ///
     /// let buffer: ProcessNoiseCovarianceMatrixMutBuffer<2, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 4);
@@ -363,6 +477,30 @@ impl<const CONTROLS: usize> ProcessNoiseCovarianceMatrixBufferBuilder<CONTROLS> 
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
     pub fn new<T>(
+        &self,
+    ) -> ProcessNoiseCovarianceMatrixMutBuffer<CONTROLS, T, MatrixDataBoxed<CONTROLS, CONTROLS, T>>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`ProcessNoiseCovarianceMatrixMutBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::ProcessNoiseCovarianceMatrixMutBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer  = BufferBuilder::process_noise_covariance_Q::<2>().new_with(0.0);
+    ///
+    /// let buffer: ProcessNoiseCovarianceMatrixMutBuffer<2, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 4);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(
         &self,
         init: T,
     ) -> ProcessNoiseCovarianceMatrixMutBuffer<CONTROLS, T, MatrixDataBoxed<CONTROLS, CONTROLS, T>>
@@ -388,7 +526,7 @@ impl<const OBSERVATIONS: usize> ObservationVectorBufferBuilder<OBSERVATIONS> {
     /// use minikalman::buffers::types::MeasurementVectorBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::measurement_vector_z::<5>().new(0.0);
+    /// let buffer = BufferBuilder::measurement_vector_z::<5>().new();
     ///
     /// let buffer: MeasurementVectorBuffer<5, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 5);
@@ -396,7 +534,29 @@ impl<const OBSERVATIONS: usize> ObservationVectorBufferBuilder<OBSERVATIONS> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> ObservationVectorBufferOwnedType<OBSERVATIONS, T>
+    pub fn new<T>(&self) -> ObservationVectorBufferOwnedType<OBSERVATIONS, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`MeasurementVectorBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::MeasurementVectorBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::measurement_vector_z::<5>().new_with(0.0);
+    ///
+    /// let buffer: MeasurementVectorBuffer<5, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 5);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> ObservationVectorBufferOwnedType<OBSERVATIONS, T>
     where
         T: Copy,
     {
@@ -421,7 +581,7 @@ impl<const OBSERVATIONS: usize, const STATES: usize>
     /// use minikalman::buffers::types::ObservationMatrixMutBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::observation_matrix_H::<5, 3>().new(0.0);
+    /// let buffer = BufferBuilder::observation_matrix_H::<5, 3>().new();
     ///
     /// let buffer: ObservationMatrixMutBuffer<5, 3, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 15);
@@ -429,7 +589,29 @@ impl<const OBSERVATIONS: usize, const STATES: usize>
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> ObservationMatrixBufferOwnedType<OBSERVATIONS, STATES, T>
+    pub fn new<T>(&self) -> ObservationMatrixBufferOwnedType<OBSERVATIONS, STATES, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`ObservationMatrixMutBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::ObservationMatrixMutBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::observation_matrix_H::<5, 3>().new_with(0.0);
+    ///
+    /// let buffer: ObservationMatrixMutBuffer<5, 3, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 15);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> ObservationMatrixBufferOwnedType<OBSERVATIONS, STATES, T>
     where
         T: Copy,
     {
@@ -461,7 +643,7 @@ impl<const OBSERVATIONS: usize> MeasurementNoiseCovarianceMatrixBufferBuilder<OB
     /// use minikalman::buffers::types::MeasurementNoiseCovarianceMatrixBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::observation_covariance_R::<5>().new(0.0);
+    /// let buffer = BufferBuilder::observation_covariance_R::<5>().new();
     ///
     /// let buffer: MeasurementNoiseCovarianceMatrixBuffer<5, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 25);
@@ -469,7 +651,29 @@ impl<const OBSERVATIONS: usize> MeasurementNoiseCovarianceMatrixBufferBuilder<OB
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> MeasurementNoiseCovarianceBufferOwnedType<OBSERVATIONS, T>
+    pub fn new<T>(&self) -> MeasurementNoiseCovarianceBufferOwnedType<OBSERVATIONS, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`MeasurementNoiseCovarianceMatrixBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::MeasurementNoiseCovarianceMatrixBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::observation_covariance_R::<5>().new_with(0.0);
+    ///
+    /// let buffer: MeasurementNoiseCovarianceMatrixBuffer<5, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 25);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> MeasurementNoiseCovarianceBufferOwnedType<OBSERVATIONS, T>
     where
         T: Copy,
     {
@@ -496,7 +700,7 @@ impl<const OBSERVATIONS: usize> InnovationVectorBufferBuilder<OBSERVATIONS> {
     /// use minikalman::buffers::types::InnovationVectorBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::innovation_vector_y::<5>().new(0.0);
+    /// let buffer = BufferBuilder::innovation_vector_y::<5>().new();
     ///
     /// let buffer: InnovationVectorBuffer<5, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 5);
@@ -504,7 +708,29 @@ impl<const OBSERVATIONS: usize> InnovationVectorBufferBuilder<OBSERVATIONS> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> InnovationVectorBufferOwnedType<OBSERVATIONS, T>
+    pub fn new<T>(&self) -> InnovationVectorBufferOwnedType<OBSERVATIONS, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`InnovationVectorBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::InnovationVectorBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::innovation_vector_y::<5>().new_with(0.0);
+    ///
+    /// let buffer: InnovationVectorBuffer<5, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 5);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> InnovationVectorBufferOwnedType<OBSERVATIONS, T>
     where
         T: Copy,
     {
@@ -531,7 +757,7 @@ impl<const OBSERVATIONS: usize> InnovationResidualCovarianceMatrixBufferBuilder<
     /// use minikalman::buffers::types::InnovationCovarianceMatrixBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::innovation_covariance_S::<5>().new(0.0);
+    /// let buffer = BufferBuilder::innovation_covariance_S::<5>().new();
     ///
     /// let buffer: InnovationCovarianceMatrixBuffer<5, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 25);
@@ -539,7 +765,29 @@ impl<const OBSERVATIONS: usize> InnovationResidualCovarianceMatrixBufferBuilder<
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(
+    pub fn new<T>(&self) -> InnovationResidualCovarianceMatrixBufferOwnedType<OBSERVATIONS, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`InnovationCovarianceMatrixBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::InnovationCovarianceMatrixBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::innovation_covariance_S::<5>().new_with(0.0);
+    ///
+    /// let buffer: InnovationCovarianceMatrixBuffer<5, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 25);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(
         &self,
         init: T,
     ) -> InnovationResidualCovarianceMatrixBufferOwnedType<OBSERVATIONS, T>
@@ -571,7 +819,7 @@ impl<const STATES: usize, const OBSERVATIONS: usize>
     /// use minikalman::buffers::types::KalmanGainMatrixBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::kalman_gain_K::<3, 5>().new(0.0);
+    /// let buffer = BufferBuilder::kalman_gain_K::<3, 5>().new();
     ///
     /// let buffer: KalmanGainMatrixBuffer<3, 5, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 15);
@@ -579,7 +827,29 @@ impl<const STATES: usize, const OBSERVATIONS: usize>
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> KalmanGainMatrixBufferOwnedType<STATES, OBSERVATIONS, T>
+    pub fn new<T>(&self) -> KalmanGainMatrixBufferOwnedType<STATES, OBSERVATIONS, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`KalmanGainMatrixBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::KalmanGainMatrixBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::kalman_gain_K::<3, 5>().new_with(0.0);
+    ///
+    /// let buffer: KalmanGainMatrixBuffer<3, 5, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 15);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> KalmanGainMatrixBufferOwnedType<STATES, OBSERVATIONS, T>
     where
         T: Copy,
     {
@@ -607,7 +877,7 @@ impl<const STATES: usize> StatePredictionVectorBufferBuilder<STATES> {
     /// use minikalman::buffers::types::PredictedStateEstimateVectorBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::state_prediction_temp_x::<3>().new(0.0);
+    /// let buffer = BufferBuilder::state_prediction_temp_x::<3>().new();
     ///
     /// let buffer: PredictedStateEstimateVectorBuffer<3, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 3);
@@ -615,7 +885,29 @@ impl<const STATES: usize> StatePredictionVectorBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> TemporaryStatePredictionVectorBufferOwnedType<STATES, T>
+    pub fn new<T>(&self) -> TemporaryStatePredictionVectorBufferOwnedType<STATES, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`PredictedStateEstimateVectorBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::PredictedStateEstimateVectorBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::state_prediction_temp_x::<3>().new_with(0.0);
+    ///
+    /// let buffer: PredictedStateEstimateVectorBuffer<3, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 3);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> TemporaryStatePredictionVectorBufferOwnedType<STATES, T>
     where
         T: Copy,
     {
@@ -638,7 +930,7 @@ impl<const STATES: usize> TemporarySystemCovarianceMatrixBufferBuilder<STATES> {
     /// use minikalman::buffers::types::TemporaryStateMatrixBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::temp_system_covariance_P::<3>().new(0.0);
+    /// let buffer = BufferBuilder::temp_system_covariance_P::<3>().new();
     ///
     /// let buffer: TemporaryStateMatrixBuffer<3, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 9);
@@ -646,7 +938,29 @@ impl<const STATES: usize> TemporarySystemCovarianceMatrixBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> TemporaryStateMatrixBufferOwnedType<STATES, T>
+    pub fn new<T>(&self) -> TemporaryStateMatrixBufferOwnedType<STATES, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`TemporaryStateMatrixBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::TemporaryStateMatrixBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::temp_system_covariance_P::<3>().new_with(0.0);
+    ///
+    /// let buffer: TemporaryStateMatrixBuffer<3, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 9);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> TemporaryStateMatrixBufferOwnedType<STATES, T>
     where
         T: Copy,
     {
@@ -669,7 +983,7 @@ impl<const STATES: usize, const CONTROLS: usize> TemporaryBQMatrixBufferBuilder<
     /// use minikalman::buffers::types::TemporaryBQMatrixBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::temp_BQ::<3, 2>().new(0.0);
+    /// let buffer = BufferBuilder::temp_BQ::<3, 2>().new();
     ///
     /// let buffer: TemporaryBQMatrixBuffer<3, 2, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 6);
@@ -677,7 +991,29 @@ impl<const STATES: usize, const CONTROLS: usize> TemporaryBQMatrixBufferBuilder<
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> TemporaryBQMatrixBufferOwnedType<STATES, CONTROLS, T>
+    pub fn new<T>(&self) -> TemporaryBQMatrixBufferOwnedType<STATES, CONTROLS, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`TemporaryBQMatrixBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::TemporaryBQMatrixBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::temp_BQ::<3, 2>().new_with(0.0);
+    ///
+    /// let buffer: TemporaryBQMatrixBuffer<3, 2, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 6);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> TemporaryBQMatrixBufferOwnedType<STATES, CONTROLS, T>
     where
         T: Copy,
     {
@@ -704,7 +1040,7 @@ impl<const OBSERVATIONS: usize> TemporarySInvMatrixBufferBuilder<OBSERVATIONS> {
     /// use minikalman::buffers::types::TemporaryResidualCovarianceInvertedMatrixBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::temp_S_inv::<5>().new(0.0);
+    /// let buffer = BufferBuilder::temp_S_inv::<5>().new();
     ///
     /// let buffer: TemporaryResidualCovarianceInvertedMatrixBuffer<5, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 25);
@@ -712,7 +1048,29 @@ impl<const OBSERVATIONS: usize> TemporarySInvMatrixBufferBuilder<OBSERVATIONS> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> TemporarySInvertedMatrixBufferOwnedType<OBSERVATIONS, T>
+    pub fn new<T>(&self) -> TemporarySInvertedMatrixBufferOwnedType<OBSERVATIONS, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`TemporaryResidualCovarianceInvertedMatrixBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::TemporaryResidualCovarianceInvertedMatrixBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::temp_S_inv::<5>().new_with(0.0);
+    ///
+    /// let buffer: TemporaryResidualCovarianceInvertedMatrixBuffer<5, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 25);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> TemporarySInvertedMatrixBufferOwnedType<OBSERVATIONS, T>
     where
         T: Copy,
     {
@@ -741,7 +1099,7 @@ impl<const OBSERVATIONS: usize, const STATES: usize>
     /// use minikalman::buffers::types::TemporaryHPMatrixBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::temp_HP::<5, 3>().new(0.0);
+    /// let buffer = BufferBuilder::temp_HP::<5, 3>().new();
     ///
     /// let buffer: TemporaryHPMatrixBuffer<5, 3, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 15);
@@ -749,7 +1107,29 @@ impl<const OBSERVATIONS: usize, const STATES: usize>
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> TemporaryHPMatrixBufferOwnedType<OBSERVATIONS, STATES, T>
+    pub fn new<T>(&self) -> TemporaryHPMatrixBufferOwnedType<OBSERVATIONS, STATES, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`TemporaryHPMatrixBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::TemporaryHPMatrixBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::temp_HP::<5, 3>().new_with(0.0);
+    ///
+    /// let buffer: TemporaryHPMatrixBuffer<5, 3, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 15);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> TemporaryHPMatrixBufferOwnedType<OBSERVATIONS, STATES, T>
     where
         T: Copy,
     {
@@ -779,7 +1159,7 @@ impl<const STATES: usize, const OBSERVATIONS: usize>
     /// use minikalman::buffers::types::TemporaryPHTMatrixBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer = BufferBuilder::temp_PHt::<3, 5>().new(0.0);
+    /// let buffer = BufferBuilder::temp_PHt::<3, 5>().new();
     ///
     /// let buffer: TemporaryPHTMatrixBuffer<3, 5, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 15);
@@ -787,7 +1167,29 @@ impl<const STATES: usize, const OBSERVATIONS: usize>
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> TemporaryPHtMatrixBufferOwnedType<STATES, OBSERVATIONS, T>
+    pub fn new<T>(&self) -> TemporaryPHtMatrixBufferOwnedType<STATES, OBSERVATIONS, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`TemporaryPHTMatrixBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::TemporaryPHTMatrixBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer = BufferBuilder::temp_PHt::<3, 5>().new_with(0.0);
+    ///
+    /// let buffer: TemporaryPHTMatrixBuffer<3, 5, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 15);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> TemporaryPHtMatrixBufferOwnedType<STATES, OBSERVATIONS, T>
     where
         T: Copy,
     {
@@ -815,7 +1217,7 @@ impl<const STATES: usize> TemporaryKHPMatrixBufferBuilder<STATES> {
     /// use minikalman::buffers::types::TemporaryKHPMatrixBuffer;
     /// use minikalman::prelude::*;
     ///
-    /// let buffer  = BufferBuilder::temp_KHP::<3>().new(0.0);
+    /// let buffer  = BufferBuilder::temp_KHP::<3>().new();
     ///
     /// let buffer: TemporaryKHPMatrixBuffer<3, f32, _> = buffer;
     /// assert_eq!(buffer.len(), 9);
@@ -823,7 +1225,29 @@ impl<const STATES: usize> TemporaryKHPMatrixBufferBuilder<STATES> {
     #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
-    pub fn new<T>(&self, init: T) -> TemporaryKHPMatrixBufferOwnedType<STATES, T>
+    pub fn new<T>(&self) -> TemporaryKHPMatrixBufferOwnedType<STATES, T>
+    where
+        T: Copy + Default,
+    {
+        self.new_with(T::default())
+    }
+
+    /// Builds a new [`TemporaryKHPMatrixBuffer`] that owns its data.
+    ///
+    /// ## Example
+    /// ```
+    /// use minikalman::buffers::types::TemporaryKHPMatrixBuffer;
+    /// use minikalman::prelude::*;
+    ///
+    /// let buffer  = BufferBuilder::temp_KHP::<3>().new_with(0.0);
+    ///
+    /// let buffer: TemporaryKHPMatrixBuffer<3, f32, _> = buffer;
+    /// assert_eq!(buffer.len(), 9);
+    /// ```
+    #[allow(clippy::new_ret_no_self, clippy::wrong_self_convention)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn new_with<T>(&self, init: T) -> TemporaryKHPMatrixBufferOwnedType<STATES, T>
     where
         T: Copy,
     {

--- a/crates/minikalman/src/controls.rs
+++ b/crates/minikalman/src/controls.rs
@@ -105,11 +105,11 @@ where
     /// The control vector contains the external inputs to the system that can influence its state.
     /// These inputs might include forces, accelerations, or other actuations applied to the system.
     #[inline(always)]
-    pub fn control_vector_inspect<F, O>(&mut self, f: F) -> O
+    pub fn control_vector_inspect<F, O>(&self, f: F) -> O
     where
         F: Fn(&U) -> O,
     {
-        f(&mut self.u)
+        f(&self.u)
     }
 
     /// Applies a function to the control vector u.

--- a/crates/minikalman/src/controls.rs
+++ b/crates/minikalman/src/controls.rs
@@ -613,13 +613,43 @@ mod tests {
         assert_f32_near!(state[3], 20.0);
     }
 
-    fn trait_impl<const STATES: usize, const CONTROLS: usize, T, M>(controls: M) -> M
+    fn trait_impl<const STATES: usize, const CONTROLS: usize, T, M>(mut control: M) -> M
     where
-        M: KalmanFilterControl<STATES, CONTROLS, T>,
+        M: KalmanFilterControl<STATES, CONTROLS, T>
+            + KalmanFilterControlTransitionMut<STATES, CONTROLS, T>,
     {
-        assert_eq!(controls.states(), STATES);
-        assert_eq!(controls.controls(), CONTROLS);
-        controls
+        assert_eq!(control.states(), STATES);
+        assert_eq!(control.controls(), CONTROLS);
+
+        let test_fn = || {};
+
+        let mut temp = 0;
+        let mut test_fn_mut = || {
+            temp += 0;
+        };
+
+        let _vec = control.control_vector_ref();
+        let _vec = control.control_vector_mut();
+        control.control_vector_inspect(|_vec| test_fn());
+        control.control_vector_inspect_mut(|_vec| test_fn_mut());
+        control.control_vector_apply(|_vec| test_fn());
+        control.control_vector_apply_mut(|_vec| test_fn_mut());
+
+        let _mat = control.control_matrix_ref();
+        let _mat = control.control_matrix_mut();
+        control.control_matrix_inspect(|_mat| test_fn());
+        control.control_matrix_inspect_mut(|_mat| test_fn_mut());
+        control.control_matrix_apply(|_mat| test_fn());
+        control.control_matrix_apply_mut(|_mat| test_fn_mut());
+
+        let _mat = control.process_noise_covariance_ref();
+        let _mat = control.process_noise_covariance_mut();
+        control.process_noise_covariance_inspect(|_mat| test_fn());
+        control.process_noise_covariance_inspect_mut(|_mat| test_fn_mut());
+        control.process_noise_covariance_apply(|_mat| test_fn());
+        control.process_noise_covariance_apply_mut(|_mat| test_fn_mut());
+
+        control
     }
 
     #[test]

--- a/crates/minikalman/src/controls.rs
+++ b/crates/minikalman/src/controls.rs
@@ -399,21 +399,21 @@ mod tests {
         const NUM_CONTROLS: usize = 3;
 
         // System buffers.
-        let x = BufferBuilder::state_vector_x::<NUM_STATES>().new(0.0_f32);
-        let A = BufferBuilder::system_matrix_A::<NUM_STATES>().new(0.0_f32);
-        let P = BufferBuilder::estimate_covariance_P::<NUM_STATES>().new(0.0_f32);
+        let x = BufferBuilder::state_vector_x::<NUM_STATES>().new();
+        let A = BufferBuilder::system_matrix_A::<NUM_STATES>().new();
+        let P = BufferBuilder::estimate_covariance_P::<NUM_STATES>().new();
 
         // Control buffers.
-        let u = BufferBuilder::control_vector_u::<NUM_CONTROLS>().new(0.0_f32);
-        let B = BufferBuilder::control_matrix_B::<NUM_STATES, NUM_CONTROLS>().new(0.0_f32);
-        let Q = BufferBuilder::process_noise_covariance_Q::<NUM_CONTROLS>().new(0.0_f32);
+        let u = BufferBuilder::control_vector_u::<NUM_CONTROLS>().new();
+        let B = BufferBuilder::control_matrix_B::<NUM_STATES, NUM_CONTROLS>().new();
+        let Q = BufferBuilder::process_noise_covariance_Q::<NUM_CONTROLS>().new();
 
         // Filter temporaries.
-        let temp_x = BufferBuilder::state_prediction_temp_x::<NUM_STATES>().new(0.0_f32);
-        let temp_P = BufferBuilder::temp_system_covariance_P::<NUM_STATES>().new(0.0_f32);
+        let temp_x = BufferBuilder::state_prediction_temp_x::<NUM_STATES>().new();
+        let temp_P = BufferBuilder::temp_system_covariance_P::<NUM_STATES>().new();
 
         // Control temporaries
-        let temp_BQ = BufferBuilder::temp_BQ::<NUM_STATES, NUM_CONTROLS>().new(0.0_f32);
+        let temp_BQ = BufferBuilder::temp_BQ::<NUM_STATES, NUM_CONTROLS>().new();
 
         let mut filter = KalmanBuilder::new::<NUM_STATES, f32>(A, x, P, temp_x, temp_P);
         let mut control = ControlBuilder::new::<NUM_STATES, NUM_CONTROLS, f32>(B, u, Q, temp_BQ);

--- a/crates/minikalman/src/controls.rs
+++ b/crates/minikalman/src/controls.rs
@@ -99,6 +99,30 @@ where
     pub fn control_vector_ref(&self) -> &U {
         &self.u
     }
+
+    /// Applies a function to the control vector u.
+    ///
+    /// The control vector contains the external inputs to the system that can influence its state.
+    /// These inputs might include forces, accelerations, or other actuations applied to the system.
+    #[inline(always)]
+    pub fn control_vector_inspect<F, O>(&mut self, f: F) -> O
+    where
+        F: Fn(&U) -> O,
+    {
+        f(&mut self.u)
+    }
+
+    /// Applies a function to the control vector u.
+    ///
+    /// The control vector contains the external inputs to the system that can influence its state.
+    /// These inputs might include forces, accelerations, or other actuations applied to the system.
+    #[inline(always)]
+    pub fn control_vector_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&U) -> O,
+    {
+        f(&self.u)
+    }
 }
 
 impl<const STATES: usize, const CONTROLS: usize, T, B, U, Q, TempBQ>
@@ -121,9 +145,9 @@ where
     /// The control vector contains the external inputs to the system that can influence its state.
     /// These inputs might include forces, accelerations, or other actuations applied to the system.
     #[inline(always)]
-    pub fn control_vector_apply<F>(&mut self, mut f: F)
+    pub fn control_vector_apply<F, O>(&mut self, mut f: F) -> O
     where
-        F: FnMut(&mut U),
+        F: FnMut(&mut U) -> O,
     {
         f(&mut self.u)
     }
@@ -136,11 +160,35 @@ where
 {
     /// Gets a reference to the control transition matrix B.
     ///
-    /// his matrix maps the control inputs to the state space, allowing the control vector to
+    /// This matrix maps the control inputs to the state space, allowing the control vector to
     /// influence the state transition. It quantifies how the control inputs affect the state change.
     #[inline(always)]
     pub fn control_matrix_ref(&self) -> &B {
         &self.B
+    }
+
+    /// Applies a function to the control transition matrix B.
+    ///
+    /// This matrix maps the control inputs to the state space, allowing the control vector to
+    /// influence the state transition. It quantifies how the control inputs affect the state change.
+    #[inline(always)]
+    pub fn control_matrix_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&B) -> O,
+    {
+        f(&self.B)
+    }
+
+    /// Applies a function to the control transition matrix B.
+    ///
+    /// This matrix maps the control inputs to the state space, allowing the control vector to
+    /// influence the state transition. It quantifies how the control inputs affect the state change.
+    #[inline(always)]
+    pub fn control_matrix_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&B) -> O,
+    {
+        f(&self.B)
     }
 }
 
@@ -151,7 +199,7 @@ where
 {
     /// Gets a mutable reference to the control transition matrix B.
     ///
-    /// his matrix maps the control inputs to the state space, allowing the control vector to
+    /// This matrix maps the control inputs to the state space, allowing the control vector to
     /// influence the state transition. It quantifies how the control inputs affect the state change.
     #[inline(always)]
     #[doc(alias = "kalman_get_control_matrix")]
@@ -161,12 +209,12 @@ where
 
     /// Applies a function to the control transition matrix B.
     ///
-    /// his matrix maps the control inputs to the state space, allowing the control vector to
+    /// This matrix maps the control inputs to the state space, allowing the control vector to
     /// influence the state transition. It quantifies how the control inputs affect the state change.
     #[inline(always)]
-    pub fn control_matrix_apply<F>(&mut self, mut f: F)
+    pub fn control_matrix_apply<F, O>(&mut self, mut f: F) -> O
     where
-        F: FnMut(&mut B),
+        F: FnMut(&mut B) -> O,
     {
         f(&mut self.B)
     }
@@ -186,6 +234,36 @@ where
     #[doc(alias = "control_covariance_ref")]
     pub fn process_noise_covariance_ref(&self) -> &Q {
         &self.Q
+    }
+
+    /// Applies a function to the control covariance matrix Q.
+    ///
+    /// This matrix represents the uncertainty in the state transition process, accounting for the
+    /// randomness and inaccuracies in the model. It quantifies the expected variability in the
+    /// state transition.
+    #[inline(always)]
+    #[doc(alias = "kalman_get_control_covariance")]
+    #[doc(alias = "control_covariance_inspect")]
+    pub fn process_noise_covariance_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&Q) -> O,
+    {
+        f(&self.Q)
+    }
+
+    /// Applies a function to the control covariance matrix Q.
+    ///
+    /// This matrix represents the uncertainty in the state transition process, accounting for the
+    /// randomness and inaccuracies in the model. It quantifies the expected variability in the
+    /// state transition.
+    #[inline(always)]
+    #[doc(alias = "kalman_get_control_covariance")]
+    #[doc(alias = "control_covariance_inspect")]
+    pub fn process_noise_covariance_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&Q) -> O,
+    {
+        f(&self.Q)
     }
 }
 
@@ -214,9 +292,9 @@ where
     #[inline(always)]
     #[doc(alias = "kalman_get_control_covariance")]
     #[doc(alias = "control_covariance_apply")]
-    pub fn process_noise_covariance_apply<F>(&mut self, mut f: F)
+    pub fn process_noise_covariance_apply<F, O>(&mut self, mut f: F) -> O
     where
-        F: FnMut(&mut Q),
+        F: FnMut(&mut Q) -> O,
     {
         f(&mut self.Q)
     }

--- a/crates/minikalman/src/controls.rs
+++ b/crates/minikalman/src/controls.rs
@@ -486,7 +486,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_dummies::{Dummy, DummyMatrix};
+    use crate::test_dummies::make_dummy_control;
 
     #[test]
     #[cfg(feature = "alloc")]
@@ -655,14 +655,11 @@ mod tests {
 
     #[test]
     fn builder_simple() {
-        let control = ControlBuilder::new::<3, 2, f32>(
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-        );
+        let control = make_dummy_control();
 
         let mut control = trait_impl(control);
+        assert_eq!(control.states(), 3);
+        assert_eq!(control.controls(), 2);
 
         let test_fn = || 42;
 
@@ -692,67 +689,5 @@ mod tests {
         control.process_noise_covariance_inspect_mut(|_mat| test_fn_mut());
         control.process_noise_covariance_apply(|_mat| test_fn());
         control.process_noise_covariance_apply_mut(|_mat| test_fn_mut());
-    }
-
-    impl<const CONTROLS: usize, T> ControlVector<CONTROLS, T> for Dummy<T> {
-        type Target = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-    impl<const CONTROLS: usize, T> ControlVectorMut<CONTROLS, T> for Dummy<T> {
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-    impl<const STATES: usize, const CONTROLS: usize, T> ControlMatrix<STATES, CONTROLS, T>
-        for Dummy<T>
-    {
-        type Target = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-    impl<const STATES: usize, const CONTROLS: usize, T> ControlMatrixMut<STATES, CONTROLS, T>
-        for Dummy<T>
-    {
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-    impl<const CONTROLS: usize, T> ProcessNoiseCovarianceMatrix<CONTROLS, T> for Dummy<T> {
-        type Target = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-    impl<const CONTROLS: usize, T> ProcessNoiseCovarianceMatrixMut<CONTROLS, T> for Dummy<T> {
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-
-    impl<const STATES: usize, const CONTROLS: usize, T> TemporaryBQMatrix<STATES, CONTROLS, T>
-        for Dummy<T>
-    {
-        type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
     }
 }

--- a/crates/minikalman/src/controls.rs
+++ b/crates/minikalman/src/controls.rs
@@ -621,11 +621,12 @@ mod tests {
         assert_eq!(control.states(), STATES);
         assert_eq!(control.controls(), CONTROLS);
 
-        let test_fn = || {};
+        let test_fn = || 42;
 
         let mut temp = 0;
         let mut test_fn_mut = || {
             temp += 0;
+            42
         };
 
         let _vec = control.control_vector_ref();
@@ -663,11 +664,12 @@ mod tests {
 
         let mut control = trait_impl(control);
 
-        let test_fn = || {};
+        let test_fn = || 42;
 
         let mut temp = 0;
         let mut test_fn_mut = || {
             temp += 0;
+            42
         };
 
         let _vec = control.control_vector_ref();

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -1,11 +1,12 @@
 use core::marker::PhantomData;
 
-mod filter_trait;
-mod matrix_types;
-
-use crate::matrix::{Matrix, MatrixDataType};
 pub use filter_trait::*;
 pub use matrix_types::*;
+
+use crate::matrix::{Matrix, MatrixDataType};
+
+mod filter_trait;
+mod matrix_types;
 
 /// A builder for a [`Kalman`] filter instances.
 #[allow(clippy::type_complexity)]
@@ -854,7 +855,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_dummies::{Dummy, DummyMatrix};
+    use crate::test_dummies::make_dummy_filter;
 
     fn trait_impl<const STATES: usize, T, K>(mut filter: K) -> K
     where
@@ -891,20 +892,17 @@ mod tests {
         filter.estimate_covariance_apply(|_mat| test_fn());
         filter.estimate_covariance_apply_mut(|_mat| test_fn_mut());
 
+        filter.predict();
+
         filter
     }
 
     #[test]
     fn builder_simple() {
-        let filter = KalmanBuilder::new::<3, f32>(
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-        );
+        let filter = make_dummy_filter();
 
         let mut filter = trait_impl(filter);
+        assert_eq!(filter.states(), 3);
 
         let test_fn = || 42;
 
@@ -934,70 +932,8 @@ mod tests {
         filter.estimate_covariance_inspect_mut(|_mat| test_fn_mut());
         filter.estimate_covariance_apply(|_mat| test_fn());
         filter.estimate_covariance_apply_mut(|_mat| test_fn_mut());
-    }
 
-    impl<const STATES: usize, T> StateVector<STATES, T> for Dummy<T> {
-        type Target = DummyMatrix<T>;
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-
-    impl<const STATES: usize, T> StateVectorMut<STATES, T> for Dummy<T> {
-        type TargetMut = DummyMatrix<T>;
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-
-    impl<const STATES: usize, T> StateTransitionMatrix<STATES, T> for Dummy<T> {
-        type Target = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-    impl<const STATES: usize, T> StateTransitionMatrixMut<STATES, T> for Dummy<T> {
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-    impl<const STATES: usize, T> EstimateCovarianceMatrix<STATES, T> for Dummy<T> {
-        type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-    impl<const STATES: usize, T> PredictedStateEstimateVector<STATES, T> for Dummy<T> {
-        type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-    impl<const STATES: usize, T> TemporaryStateMatrix<STATES, T> for Dummy<T> {
-        type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
+        filter.predict();
     }
 
     #[test]

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -342,7 +342,7 @@ where
     /// state estimate is expected to vary, providing a measure of confidence in the estimate.
     #[inline(always)]
     #[doc(alias = "system_covariance_inspect")]
-    pub fn estimate_covariance_inspect<F, O>(&mut self, f: F) -> O
+    pub fn estimate_covariance_inspect<F, O>(&self, f: F) -> O
     where
         F: Fn(&P) -> O,
     {

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -862,11 +862,12 @@ mod tests {
     {
         assert_eq!(filter.states(), STATES);
 
-        let test_fn = || {};
+        let test_fn = || 42;
 
         let mut temp = 0;
         let mut test_fn_mut = || {
             temp += 0;
+            42
         };
 
         let _vec = filter.state_vector_ref();
@@ -905,11 +906,12 @@ mod tests {
 
         let mut filter = trait_impl(filter);
 
-        let test_fn = || {};
+        let test_fn = || 42;
 
         let mut temp = 0;
         let mut test_fn_mut = || {
             temp += 0;
+            42
         };
 
         let _vec = filter.state_vector_ref();

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -512,12 +512,12 @@ impl<const STATES: usize, T, A, X, P, PX, TempP> Kalman<STATES, T, A, X, P, PX, 
     }
 
     #[inline(always)]
-    pub fn control<const CONTROLS: usize, I>(&mut self, control: &mut I)
+    pub fn control<I>(&mut self, control: &mut I)
     where
         P: EstimateCovarianceMatrix<STATES, T>,
         X: StateVectorMut<STATES, T>,
         T: MatrixDataType,
-        I: KalmanFilterControlApplyToFilter<STATES, T> + KalmanFilterNumControls<CONTROLS>,
+        I: KalmanFilterControlApplyToFilter<STATES, T>,
     {
         control.apply_to(&mut self.x, &mut self.P)
     }
@@ -727,9 +727,9 @@ where
     T: MatrixDataType,
 {
     #[inline(always)]
-    fn control<const CONTROLS: usize, I>(&mut self, control: &mut I)
+    fn control<I>(&mut self, control: &mut I)
     where
-        I: KalmanFilterControlApplyToFilter<STATES, T> + KalmanFilterNumControls<CONTROLS>,
+        I: KalmanFilterControlApplyToFilter<STATES, T>,
     {
         self.control(control)
     }

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -1,3 +1,4 @@
+use core::borrow::BorrowMut;
 use core::marker::PhantomData;
 
 mod filter_trait;
@@ -592,14 +593,12 @@ impl<const STATES: usize, T, A, X, P, PX, TempP> Kalman<STATES, T, A, X, P, PX, 
     ///     filter.correct(&mut measurement);
     /// }
     /// ```
-    #[allow(non_snake_case)]
-    pub fn correct<const OBSERVATIONS: usize, M>(&mut self, measurement: &mut M)
+    pub fn correct<M>(&mut self, measurement: &mut M)
     where
         P: EstimateCovarianceMatrix<STATES, T>,
         X: StateVectorMut<STATES, T>,
         T: MatrixDataType,
-        M: KalmanFilterObservationCorrectFilter<STATES, T>
-            + KalmanFilterNumObservations<OBSERVATIONS>,
+        M: KalmanFilterObservationCorrectFilter<STATES, T>,
     {
         measurement.correct(&mut self.x, &mut self.P);
     }
@@ -712,12 +711,11 @@ where
     T: MatrixDataType,
 {
     #[inline(always)]
-    fn correct<const OBSERVATIONS: usize, M>(&mut self, measurement: &mut M)
+    fn correct<M>(&mut self, measurement: &mut M)
     where
-        M: KalmanFilterObservationCorrectFilter<STATES, T>
-            + KalmanFilterNumObservations<OBSERVATIONS>,
+        M: KalmanFilterObservationCorrectFilter<STATES, T>,
     {
-        self.correct(measurement)
+        self.correct(measurement.borrow_mut())
     }
 }
 

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -856,12 +856,41 @@ mod tests {
     use super::*;
     use crate::test_dummies::{Dummy, DummyMatrix};
 
-    fn trait_impl<const STATES: usize, T, M>(controls: M) -> M
+    fn trait_impl<const STATES: usize, T, K>(mut filter: K) -> K
     where
-        M: KalmanFilter<STATES, T>,
+        K: KalmanFilter<STATES, T> + KalmanFilterStateTransitionMut<STATES, T>,
     {
-        assert_eq!(controls.states(), STATES);
-        controls
+        assert_eq!(filter.states(), STATES);
+
+        let test_fn = || {};
+
+        let mut temp = 0;
+        let mut test_fn_mut = || {
+            temp += 0;
+        };
+
+        let _vec = filter.state_vector_ref();
+        let _vec = filter.state_vector_mut();
+        filter.state_vector_inspect(|_vec| test_fn());
+        filter.state_vector_inspect_mut(|_vec| test_fn_mut());
+        filter.state_vector_apply(|_vec| test_fn());
+        filter.state_vector_apply_mut(|_vec| test_fn_mut());
+
+        let _mat = filter.state_transition_ref();
+        let _mat = filter.state_transition_mut();
+        filter.state_transition_inspect(|_mat| test_fn());
+        filter.state_transition_inspect_mut(|_mat| test_fn_mut());
+        filter.state_transition_apply(|_mat| test_fn());
+        filter.state_transition_apply_mut(|_mat| test_fn_mut());
+
+        let _mat = filter.estimate_covariance_ref();
+        let _mat = filter.estimate_covariance_mut();
+        filter.estimate_covariance_inspect(|_mat| test_fn());
+        filter.estimate_covariance_inspect_mut(|_mat| test_fn_mut());
+        filter.estimate_covariance_apply(|_mat| test_fn());
+        filter.estimate_covariance_apply_mut(|_mat| test_fn_mut());
+
+        filter
     }
 
     #[test]

--- a/crates/minikalman/src/kalman/filter_trait.rs
+++ b/crates/minikalman/src/kalman/filter_trait.rs
@@ -93,9 +93,9 @@ pub trait KalmanFilterApplyControl<const STATES: usize, T> {
     ///
     /// ## Arguments
     /// * `measurement` - The measurement to update the state prediction with.
-    fn control<const CONTROLS: usize, I>(&mut self, control: &mut I)
+    fn control<I>(&mut self, control: &mut I)
     where
-        I: KalmanFilterControlApplyToFilter<STATES, T> + KalmanFilterNumControls<CONTROLS>;
+        I: KalmanFilterControlApplyToFilter<STATES, T>;
 }
 
 pub trait KalmanFilterUpdate<const STATES: usize, T> {

--- a/crates/minikalman/src/kalman/filter_trait.rs
+++ b/crates/minikalman/src/kalman/filter_trait.rs
@@ -116,6 +116,30 @@ pub trait KalmanFilterStateVector<const STATES: usize, T> {
     /// The state vector represents the internal state of the system at a given time.
     /// It contains all the necessary information to describe the system's current situation.
     fn state_vector_ref(&self) -> &Self::StateVector;
+
+    /// Applies a function to the state vector x.
+    ///
+    /// The state vector represents the internal state of the system at a given time.
+    /// It contains all the necessary information to describe the system's current situation.
+    #[inline(always)]
+    fn state_vector_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&Self::StateVector) -> O,
+    {
+        f(self.state_vector_ref())
+    }
+
+    /// Applies a function to the state vector x.
+    ///
+    /// The state vector represents the internal state of the system at a given time.
+    /// It contains all the necessary information to describe the system's current situation.
+    #[inline(always)]
+    fn state_vector_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&Self::StateVector) -> O,
+    {
+        f(self.state_vector_ref())
+    }
 }
 
 pub trait KalmanFilterStateVectorMut<const STATES: usize, T>:
@@ -135,9 +159,21 @@ pub trait KalmanFilterStateVectorMut<const STATES: usize, T>:
     /// The state vector represents the internal state of the system at a given time.
     /// It contains all the necessary information to describe the system's current situation.
     #[inline(always)]
-    fn state_vector_apply<F>(&mut self, mut f: F)
+    fn state_vector_apply<F, O>(&mut self, f: F) -> O
     where
-        F: FnMut(&mut Self::StateVectorMut),
+        F: Fn(&mut Self::StateVectorMut) -> O,
+    {
+        f(self.state_vector_mut())
+    }
+
+    /// Applies a function to the state vector x.
+    ///
+    /// The state vector represents the internal state of the system at a given time.
+    /// It contains all the necessary information to describe the system's current situation.
+    #[inline(always)]
+    fn state_vector_apply_mut<F, O>(&mut self, mut f: F) -> O
+    where
+        F: FnMut(&mut Self::StateVectorMut) -> O,
     {
         f(self.state_vector_mut())
     }
@@ -152,6 +188,32 @@ pub trait KalmanFilterStateTransition<const STATES: usize, T> {
     /// absence of control inputs. It defines the relationship between the previous state and the
     /// current state, accounting for the inherent dynamics of the system.
     fn state_transition_ref(&self) -> &Self::StateTransitionMatrix;
+
+    /// Applies a function to the state transition matrix A/F.
+    ///
+    /// This matrix describes how the state vector evolves from one time step to the next in the
+    /// absence of control inputs. It defines the relationship between the previous state and the
+    /// current state, accounting for the inherent dynamics of the system.
+    #[inline(always)]
+    fn state_transition_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&Self::StateTransitionMatrix) -> O,
+    {
+        f(self.state_transition_ref())
+    }
+
+    /// Applies a function to the state transition matrix A/F.
+    ///
+    /// This matrix describes how the state vector evolves from one time step to the next in the
+    /// absence of control inputs. It defines the relationship between the previous state and the
+    /// current state, accounting for the inherent dynamics of the system.
+    #[inline(always)]
+    fn state_transition_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&Self::StateTransitionMatrix) -> O,
+    {
+        f(self.state_transition_ref())
+    }
 }
 
 pub trait KalmanFilterStateTransitionMut<const STATES: usize, T>:
@@ -173,9 +235,22 @@ pub trait KalmanFilterStateTransitionMut<const STATES: usize, T>:
     /// absence of control inputs. It defines the relationship between the previous state and the
     /// current state, accounting for the inherent dynamics of the system.
     #[inline(always)]
-    fn state_transition_apply<F>(&mut self, mut f: F)
+    fn state_transition_apply<F, O>(&mut self, f: F) -> O
     where
-        F: FnMut(&mut Self::StateTransitionMatrixMut),
+        F: Fn(&mut Self::StateTransitionMatrixMut) -> O,
+    {
+        f(self.state_transition_mut())
+    }
+
+    /// Applies a function to the state transition matrix A/F.
+    ///
+    /// This matrix describes how the state vector evolves from one time step to the next in the
+    /// absence of control inputs. It defines the relationship between the previous state and the
+    /// current state, accounting for the inherent dynamics of the system.
+    #[inline(always)]
+    fn state_transition_apply_mut<F, O>(&mut self, mut f: F) -> O
+    where
+        F: FnMut(&mut Self::StateTransitionMatrixMut) -> O,
     {
         f(self.state_transition_mut())
     }
@@ -190,6 +265,32 @@ pub trait KalmanFilterSystemCovariance<const STATES: usize, T> {
     /// state estimate is expected to vary, providing a measure of confidence in the estimate.
     #[doc(alias = "system_covariance_ref")]
     fn estimate_covariance_ref(&self) -> &Self::EstimateCovarianceMatrix;
+
+    /// Applies a function to the estimate covariance matrix P.
+    ///
+    /// This matrix represents the uncertainty in the state estimate. It quantifies how much the
+    /// state estimate is expected to vary, providing a measure of confidence in the estimate.
+    #[inline(always)]
+    #[doc(alias = "system_covariance_inspect")]
+    fn estimate_covariance_inspect<F, O>(&mut self, f: F) -> O
+    where
+        F: Fn(&Self::EstimateCovarianceMatrix) -> O,
+    {
+        f(self.estimate_covariance_ref())
+    }
+
+    /// Applies a function to the estimate covariance matrix P.
+    ///
+    /// This matrix represents the uncertainty in the state estimate. It quantifies how much the
+    /// state estimate is expected to vary, providing a measure of confidence in the estimate.
+    #[inline(always)]
+    #[doc(alias = "system_covariance_inspect_mut")]
+    fn estimate_covariance_inspect_mut<F, O>(&mut self, f: F) -> O
+    where
+        F: Fn(&Self::EstimateCovarianceMatrix) -> O,
+    {
+        f(self.estimate_covariance_ref())
+    }
 }
 
 pub trait KalmanFilterSystemCovarianceMut<const STATES: usize, T>:
@@ -211,9 +312,22 @@ pub trait KalmanFilterSystemCovarianceMut<const STATES: usize, T>:
     /// state estimate is expected to vary, providing a measure of confidence in the estimate.
     #[inline(always)]
     #[doc(alias = "system_covariance_apply")]
-    fn estimate_covariance_apply<F>(&mut self, mut f: F)
+    fn estimate_covariance_apply<F, O>(&mut self, f: F) -> O
     where
-        F: FnMut(&mut Self::EstimateCovarianceMatrixMut),
+        F: Fn(&mut Self::EstimateCovarianceMatrixMut) -> O,
+    {
+        f(self.estimate_covariance_mut())
+    }
+
+    /// Applies a function to the estimate covariance matrix P.
+    ///
+    /// This matrix represents the uncertainty in the state estimate. It quantifies how much the
+    /// state estimate is expected to vary, providing a measure of confidence in the estimate.
+    #[inline(always)]
+    #[doc(alias = "system_covariance_apply_mut")]
+    fn estimate_covariance_apply_mut<F, O>(&mut self, mut f: F) -> O
+    where
+        F: FnMut(&mut Self::EstimateCovarianceMatrixMut) -> O,
     {
         f(self.estimate_covariance_mut())
     }
@@ -250,6 +364,30 @@ pub trait KalmanFilterControlVector<const CONTROLS: usize, T> {
     /// The control vector contains the external inputs to the system that can influence its state.
     /// These inputs might include forces, accelerations, or other actuations applied to the system.
     fn control_vector_ref(&self) -> &Self::ControlVector;
+
+    /// Applies a function to the control vector u.
+    ///
+    /// The control vector contains the external inputs to the system that can influence its state.
+    /// These inputs might include forces, accelerations, or other actuations applied to the system.
+    #[inline(always)]
+    fn control_vector_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&Self::ControlVector) -> O,
+    {
+        f(self.control_vector_ref())
+    }
+
+    /// Applies a function to the control vector u.
+    ///
+    /// The control vector contains the external inputs to the system that can influence its state.
+    /// These inputs might include forces, accelerations, or other actuations applied to the system.
+    #[inline(always)]
+    fn control_vector_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&Self::ControlVector) -> O,
+    {
+        f(self.control_vector_ref())
+    }
 }
 
 pub trait KalmanFilterControlVectorMut<const CONTROLS: usize, T>:
@@ -269,9 +407,21 @@ pub trait KalmanFilterControlVectorMut<const CONTROLS: usize, T>:
     /// The control vector contains the external inputs to the system that can influence its state.
     /// These inputs might include forces, accelerations, or other actuations applied to the system.
     #[inline(always)]
-    fn control_vector_apply<F>(&mut self, mut f: F)
+    fn control_vector_apply<F, O>(&mut self, f: F) -> O
     where
-        F: FnMut(&mut Self::ControlVectorMut),
+        F: Fn(&mut Self::ControlVectorMut) -> O,
+    {
+        f(self.control_vector_mut())
+    }
+
+    /// Applies a function to the control vector u.
+    ///
+    /// The control vector contains the external inputs to the system that can influence its state.
+    /// These inputs might include forces, accelerations, or other actuations applied to the system.
+    #[inline(always)]
+    fn control_vector_apply_mut<F, O>(&mut self, mut f: F) -> O
+    where
+        F: FnMut(&mut Self::ControlVectorMut) -> O,
     {
         f(self.control_vector_mut())
     }
@@ -285,6 +435,30 @@ pub trait KalmanFilterControlTransition<const STATES: usize, const CONTROLS: usi
     /// This matrix maps the control inputs to the state space, allowing the control vector to
     /// influence the state transition. It quantifies how the control inputs affect the state change.
     fn control_matrix_ref(&self) -> &Self::ControlTransitionMatrix;
+
+    /// Applies a function to the control transition matrix B.
+    ///
+    /// This matrix maps the control inputs to the state space, allowing the control vector to
+    /// influence the state transition. It quantifies how the control inputs affect the state change.
+    #[inline(always)]
+    fn control_matrix_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&Self::ControlTransitionMatrix) -> O,
+    {
+        f(self.control_matrix_ref())
+    }
+
+    /// Applies a function to the control transition matrix B.
+    ///
+    /// This matrix maps the control inputs to the state space, allowing the control vector to
+    /// influence the state transition. It quantifies how the control inputs affect the state change.
+    #[inline(always)]
+    fn control_matrix_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&Self::ControlTransitionMatrix) -> O,
+    {
+        f(self.control_matrix_ref())
+    }
 }
 
 pub trait KalmanFilterControlTransitionMut<const STATES: usize, const CONTROLS: usize, T>:
@@ -304,9 +478,21 @@ pub trait KalmanFilterControlTransitionMut<const STATES: usize, const CONTROLS: 
     /// This matrix maps the control inputs to the state space, allowing the control vector to
     /// influence the state transition. It quantifies how the control inputs affect the state change.
     #[inline(always)]
-    fn control_matrix_apply<F>(&mut self, mut f: F)
+    fn control_matrix_apply<F, O>(&mut self, f: F) -> O
     where
-        F: FnMut(&mut Self::ControlTransitionMatrixMut),
+        F: Fn(&mut Self::ControlTransitionMatrixMut) -> O,
+    {
+        f(self.control_matrix_mut())
+    }
+
+    /// Applies a function to the control transition matrix B.
+    ///
+    /// This matrix maps the control inputs to the state space, allowing the control vector to
+    /// influence the state transition. It quantifies how the control inputs affect the state change.
+    #[inline(always)]
+    fn control_matrix_apply_mut<F, O>(&mut self, mut f: F) -> O
+    where
+        F: FnMut(&mut Self::ControlTransitionMatrixMut) -> O,
     {
         f(self.control_matrix_mut())
     }
@@ -323,6 +509,34 @@ pub trait KalmanFilterProcessNoiseCovariance<const CONTROLS: usize, T> {
     /// state transition.
     #[doc(alias = "control_covariance_ref")]
     fn process_noise_covariance_ref(&self) -> &Self::ProcessNoiseCovarianceMatrix;
+
+    /// Applies a function to the control covariance matrix Q.
+    ///
+    /// This matrix represents the uncertainty in the state transition process, accounting for the
+    /// randomness and inaccuracies in the model. It quantifies the expected variability in the
+    /// state transition.
+    #[inline(always)]
+    #[doc(alias = "control_covariance_inspect")]
+    fn process_noise_covariance_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&Self::ProcessNoiseCovarianceMatrix) -> O,
+    {
+        f(self.process_noise_covariance_ref())
+    }
+
+    /// Applies a function to the control covariance matrix Q.
+    ///
+    /// This matrix represents the uncertainty in the state transition process, accounting for the
+    /// randomness and inaccuracies in the model. It quantifies the expected variability in the
+    /// state transition.
+    #[inline(always)]
+    #[doc(alias = "control_covariance_inspect_mut")]
+    fn process_noise_covariance_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&Self::ProcessNoiseCovarianceMatrix) -> O,
+    {
+        f(self.process_noise_covariance_ref())
+    }
 }
 
 pub trait KalmanFilterControlCovarianceMut<const CONTROLS: usize, T>:
@@ -346,9 +560,23 @@ pub trait KalmanFilterControlCovarianceMut<const CONTROLS: usize, T>:
     /// state transition.
     #[inline(always)]
     #[doc(alias = "control_covariance_apply")]
-    fn process_noise_covariance_apply<F>(&mut self, mut f: F)
+    fn process_noise_covariance_apply<F, O>(&mut self, f: F) -> O
     where
-        F: FnMut(&mut Self::ProcessNoiseCovarianceMatrixMut),
+        F: Fn(&mut Self::ProcessNoiseCovarianceMatrixMut) -> O,
+    {
+        f(self.process_noise_covariance_mut())
+    }
+
+    /// Applies a function to the control covariance matrix Q.
+    ///
+    /// This matrix represents the uncertainty in the state transition process, accounting for the
+    /// randomness and inaccuracies in the model. It quantifies the expected variability in the
+    /// state transition.
+    #[inline(always)]
+    #[doc(alias = "control_covariance_apply_mut")]
+    fn process_noise_covariance_apply_mut<F, O>(&mut self, mut f: F) -> O
+    where
+        F: FnMut(&mut Self::ProcessNoiseCovarianceMatrixMut) -> O,
     {
         f(self.process_noise_covariance_mut())
     }
@@ -385,6 +613,30 @@ pub trait KalmanFilterMeasurementVector<const OBSERVATIONS: usize, T> {
     /// The measurement vector represents the observed measurements from the system.
     /// These measurements are typically taken from sensors and are used to update the state estimate.
     fn measurement_vector_ref(&self) -> &Self::MeasurementVector;
+
+    /// Applies a function to the measurement vector z.
+    ///
+    /// The measurement vector represents the observed measurements from the system.
+    /// These measurements are typically taken from sensors and are used to update the state estimate.
+    #[inline(always)]
+    fn measurement_vector_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&Self::MeasurementVector) -> O,
+    {
+        f(self.measurement_vector_ref())
+    }
+
+    /// Applies a function to the measurement vector z.
+    ///
+    /// The measurement vector represents the observed measurements from the system.
+    /// These measurements are typically taken from sensors and are used to update the state estimate.
+    #[inline(always)]
+    fn measurement_vector_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&Self::MeasurementVector) -> O,
+    {
+        f(self.measurement_vector_ref())
+    }
 }
 
 pub trait KalmanFilterObservationVectorMut<const OBSERVATIONS: usize, T>:
@@ -404,9 +656,21 @@ pub trait KalmanFilterObservationVectorMut<const OBSERVATIONS: usize, T>:
     /// The measurement vector represents the observed measurements from the system.
     /// These measurements are typically taken from sensors and are used to update the state estimate.
     #[inline(always)]
-    fn measurement_vector_apply<F>(&mut self, mut f: F)
+    fn measurement_vector_apply<F, O>(&mut self, f: F) -> O
     where
-        F: FnMut(&mut Self::MeasurementVectorMut),
+        F: Fn(&mut Self::MeasurementVectorMut) -> O,
+    {
+        f(self.measurement_vector_mut())
+    }
+
+    /// Applies a function to the measurement vector z.
+    ///
+    /// The measurement vector represents the observed measurements from the system.
+    /// These measurements are typically taken from sensors and are used to update the state estimate.
+    #[inline(always)]
+    fn measurement_vector_apply_mut<F, O>(&mut self, mut f: F) -> O
+    where
+        F: FnMut(&mut Self::MeasurementVectorMut) -> O,
     {
         f(self.measurement_vector_mut())
     }
@@ -421,6 +685,32 @@ pub trait KalmanFilterObservationTransformation<const STATES: usize, const OBSER
     /// system to the observations or measurements. It defines how each state component contributes
     /// to the measurement.
     fn observation_matrix_ref(&self) -> &Self::ObservationTransformationMatrix;
+
+    /// Applies a function to the measurement transformation matrix H.
+    ///
+    /// This matrix maps the state vector into the measurement space, relating the state of the
+    /// system to the observations or measurements. It defines how each state component contributes
+    /// to the measurement.
+    #[inline(always)]
+    fn observation_matrix_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&Self::ObservationTransformationMatrix) -> O,
+    {
+        f(self.observation_matrix_ref())
+    }
+
+    /// Applies a function to the measurement transformation matrix H.
+    ///
+    /// This matrix maps the state vector into the measurement space, relating the state of the
+    /// system to the observations or measurements. It defines how each state component contributes
+    /// to the measurement.
+    #[inline(always)]
+    fn observation_matrix_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&Self::ObservationTransformationMatrix) -> O,
+    {
+        f(self.observation_matrix_ref())
+    }
 }
 
 pub trait KalmanFilterObservationTransformationMut<
@@ -446,9 +736,22 @@ pub trait KalmanFilterObservationTransformationMut<
     /// system to the observations or measurements. It defines how each state component contributes
     /// to the measurement.
     #[inline(always)]
-    fn observation_matrix_apply<F>(&mut self, mut f: F)
+    fn observation_matrix_apply<F, O>(&mut self, f: F) -> O
     where
-        F: FnMut(&mut Self::ObservationTransformationMatrixMut),
+        F: Fn(&mut Self::ObservationTransformationMatrixMut) -> O,
+    {
+        f(self.observation_matrix_mut())
+    }
+
+    /// Applies a function to the measurement transformation matrix H.
+    ///
+    /// This matrix maps the state vector into the measurement space, relating the state of the
+    /// system to the observations or measurements. It defines how each state component contributes
+    /// to the measurement.
+    #[inline(always)]
+    fn observation_matrix_apply_mut<F, O>(&mut self, mut f: F) -> O
+    where
+        F: FnMut(&mut Self::ObservationTransformationMatrixMut) -> O,
     {
         f(self.observation_matrix_mut())
     }
@@ -462,15 +765,36 @@ pub trait KalmanFilterMeasurementNoiseCovariance<const OBSERVATIONS: usize, T> {
     /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
     /// inaccuracies. It quantifies the expected variability in the measurement process.
     fn measurement_noise_covariance_ref(&self) -> &Self::MeasurementNoiseCovarianceMatrix;
+
+    /// Applies a function to the process noise matrix R.
+    ///
+    /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
+    /// inaccuracies. It quantifies the expected variability in the measurement process.
+    #[inline(always)]
+    fn measurement_noise_covariance_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&Self::MeasurementNoiseCovarianceMatrix) -> O,
+    {
+        f(self.measurement_noise_covariance_ref())
+    }
+
+    /// Applies a function to the process noise matrix R.
+    ///
+    /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
+    /// inaccuracies. It quantifies the expected variability in the measurement process.
+    #[inline(always)]
+    fn measurement_noise_covariance_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&Self::MeasurementNoiseCovarianceMatrix) -> O,
+    {
+        f(self.measurement_noise_covariance_ref())
+    }
 }
 
 pub trait KalmanFilterMeasurementNoiseCovarianceMut<const OBSERVATIONS: usize, T>:
     KalmanFilterMeasurementNoiseCovariance<OBSERVATIONS, T>
 {
-    type KalmanFilterMeasurementNoiseCovarianceMut: MeasurementNoiseCovarianceMatrix<
-        OBSERVATIONS,
-        T,
-    >;
+    type MeasurementNoiseCovarianceMatrixMut: MeasurementNoiseCovarianceMatrix<OBSERVATIONS, T>;
 
     /// Gets a mutable reference to the process noise matrix R.
     ///
@@ -479,16 +803,28 @@ pub trait KalmanFilterMeasurementNoiseCovarianceMut<const OBSERVATIONS: usize, T
     #[doc(alias = "kalman_get_process_noise")]
     fn measurement_noise_covariance_mut(
         &mut self,
-    ) -> &mut Self::KalmanFilterMeasurementNoiseCovarianceMut;
+    ) -> &mut Self::MeasurementNoiseCovarianceMatrixMut;
 
     /// Applies a function to the process noise matrix R.
     ///
     /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
     /// inaccuracies. It quantifies the expected variability in the measurement process.
     #[inline(always)]
-    fn measurement_noise_covariance_apply<F>(&mut self, mut f: F)
+    fn measurement_noise_covariance_apply<F, O>(&mut self, f: F) -> O
     where
-        F: FnMut(&mut Self::KalmanFilterMeasurementNoiseCovarianceMut),
+        F: Fn(&mut Self::MeasurementNoiseCovarianceMatrixMut) -> O,
+    {
+        f(self.measurement_noise_covariance_mut())
+    }
+
+    /// Applies a function to the process noise matrix R.
+    ///
+    /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
+    /// inaccuracies. It quantifies the expected variability in the measurement process.
+    #[inline(always)]
+    fn measurement_noise_covariance_apply_mut<F, O>(&mut self, mut f: F) -> O
+    where
+        F: FnMut(&mut Self::MeasurementNoiseCovarianceMatrixMut) -> O,
     {
         f(self.measurement_noise_covariance_mut())
     }

--- a/crates/minikalman/src/kalman/filter_trait.rs
+++ b/crates/minikalman/src/kalman/filter_trait.rs
@@ -285,9 +285,9 @@ pub trait KalmanFilterSystemCovariance<const STATES: usize, T> {
     /// state estimate is expected to vary, providing a measure of confidence in the estimate.
     #[inline(always)]
     #[doc(alias = "system_covariance_inspect_mut")]
-    fn estimate_covariance_inspect_mut<F, O>(&mut self, f: F) -> O
+    fn estimate_covariance_inspect_mut<F, O>(&mut self, mut f: F) -> O
     where
-        F: Fn(&Self::EstimateCovarianceMatrix) -> O,
+        F: FnMut(&Self::EstimateCovarianceMatrix) -> O,
     {
         f(self.estimate_covariance_ref())
     }

--- a/crates/minikalman/src/kalman/filter_trait.rs
+++ b/crates/minikalman/src/kalman/filter_trait.rs
@@ -1,9 +1,4 @@
-use crate::kalman::{
-    ControlMatrix, ControlMatrixMut, ControlVector, ControlVectorMut, EstimateCovarianceMatrix,
-    MeasurementNoiseCovarianceMatrix, MeasurementVector, MeasurementVectorMut, ObservationMatrix,
-    ObservationMatrixMut, ProcessNoiseCovarianceMatrix, ProcessNoiseCovarianceMatrixMut,
-    StateTransitionMatrix, StateTransitionMatrixMut, StateVector, StateVectorMut,
-};
+use crate::kalman::*;
 
 /// A Kalman filter.
 pub trait KalmanFilter<const STATES: usize, T>:
@@ -108,10 +103,9 @@ pub trait KalmanFilterUpdate<const STATES: usize, T> {
     ///
     /// ## Arguments
     /// * `measurement` - The measurement to update the state prediction with.
-    fn correct<const OBSERVATIONS: usize, M>(&mut self, measurement: &mut M)
+    fn correct<M>(&mut self, measurement: &mut M)
     where
-        M: KalmanFilterObservationCorrectFilter<STATES, T>
-            + KalmanFilterNumObservations<OBSERVATIONS>;
+        M: KalmanFilterObservationCorrectFilter<STATES, T>;
 }
 
 pub trait KalmanFilterStateVector<const STATES: usize, T> {

--- a/crates/minikalman/src/kalman/filter_trait.rs
+++ b/crates/minikalman/src/kalman/filter_trait.rs
@@ -272,7 +272,7 @@ pub trait KalmanFilterSystemCovariance<const STATES: usize, T> {
     /// state estimate is expected to vary, providing a measure of confidence in the estimate.
     #[inline(always)]
     #[doc(alias = "system_covariance_inspect")]
-    fn estimate_covariance_inspect<F, O>(&mut self, f: F) -> O
+    fn estimate_covariance_inspect<F, O>(&self, f: F) -> O
     where
         F: Fn(&Self::EstimateCovarianceMatrix) -> O,
     {
@@ -285,7 +285,7 @@ pub trait KalmanFilterSystemCovariance<const STATES: usize, T> {
     /// state estimate is expected to vary, providing a measure of confidence in the estimate.
     #[inline(always)]
     #[doc(alias = "system_covariance_inspect_mut")]
-    fn estimate_covariance_inspect_mut<F, O>(&mut self, mut f: F) -> O
+    fn estimate_covariance_inspect_mut<F, O>(&self, mut f: F) -> O
     where
         F: FnMut(&Self::EstimateCovarianceMatrix) -> O,
     {

--- a/crates/minikalman/src/kalman_builder.rs
+++ b/crates/minikalman/src/kalman_builder.rs
@@ -62,19 +62,16 @@ impl<const STATES: usize, T> KalmanFilterBuilder<STATES, T> {
     /// See also [`KalmanFilterControlBuilder`] and [`KalmanFilterObservationBuilder`] for further information.
     pub fn build(&self) -> KalmanFilterType<STATES, T>
     where
-        T: MatrixDataType,
+        T: MatrixDataType + Default,
     {
-        // The initialization value.
-        let zero = T::zero();
-
         // System buffers.
-        let state_vector = BufferBuilder::state_vector_x::<STATES>().new(zero);
-        let system_matrix = BufferBuilder::system_matrix_A::<STATES>().new(zero);
-        let system_covariance = BufferBuilder::estimate_covariance_P::<STATES>().new(zero);
+        let state_vector = BufferBuilder::state_vector_x::<STATES>().new();
+        let system_matrix = BufferBuilder::system_matrix_A::<STATES>().new();
+        let system_covariance = BufferBuilder::estimate_covariance_P::<STATES>().new();
 
         // Filter temporaries.
-        let temp_x = BufferBuilder::state_prediction_temp_x::<STATES>().new(zero);
-        let temp_p = BufferBuilder::temp_system_covariance_P::<STATES>().new(zero);
+        let temp_x = BufferBuilder::state_prediction_temp_x::<STATES>().new();
+        let temp_p = BufferBuilder::temp_system_covariance_P::<STATES>().new();
 
         KalmanBuilder::new::<STATES, T>(
             system_matrix,
@@ -138,18 +135,15 @@ impl<const STATES: usize, T> KalmanFilterControlBuilder<STATES, T> {
     /// See also [`KalmanFilterBuilder`] and [`KalmanFilterObservationBuilder`] for further information.
     pub fn build<const CONTROLS: usize>(&self) -> KalmanFilterControlType<STATES, CONTROLS, T>
     where
-        T: MatrixDataType,
+        T: MatrixDataType + Default,
     {
-        // The initialization value.
-        let zero = T::zero();
-
         // Control buffers.
-        let control_vector = BufferBuilder::control_vector_u::<CONTROLS>().new(zero);
-        let control_matrix = BufferBuilder::control_matrix_B::<STATES, CONTROLS>().new(zero);
-        let control_covariance = BufferBuilder::process_noise_covariance_Q::<CONTROLS>().new(zero);
+        let control_vector = BufferBuilder::control_vector_u::<CONTROLS>().new();
+        let control_matrix = BufferBuilder::control_matrix_B::<STATES, CONTROLS>().new();
+        let control_covariance = BufferBuilder::process_noise_covariance_Q::<CONTROLS>().new();
 
         // Control temporaries.
-        let temp_bq = BufferBuilder::temp_BQ::<STATES, CONTROLS>().new(zero);
+        let temp_bq = BufferBuilder::temp_BQ::<STATES, CONTROLS>().new();
 
         ControlBuilder::new::<STATES, CONTROLS, T>(
             control_matrix,
@@ -211,27 +205,24 @@ impl<const STATES: usize, T> KalmanFilterObservationBuilder<STATES, T> {
         &self,
     ) -> KalmanFilterObservationType<STATES, OBSERVATIONS, T>
     where
-        T: MatrixDataType,
+        T: MatrixDataType + Default,
     {
-        // The initialization value.
-        let zero = T::zero();
-
         // Observation buffers.
-        let measurement_vector = BufferBuilder::measurement_vector_z::<OBSERVATIONS>().new(zero);
+        let measurement_vector = BufferBuilder::measurement_vector_z::<OBSERVATIONS>().new();
         let observation_matrix =
-            BufferBuilder::observation_matrix_H::<OBSERVATIONS, STATES>().new(zero);
+            BufferBuilder::observation_matrix_H::<OBSERVATIONS, STATES>().new();
         let observation_covariance =
-            BufferBuilder::observation_covariance_R::<OBSERVATIONS>().new(zero);
-        let innovation_vector = BufferBuilder::innovation_vector_y::<OBSERVATIONS>().new(zero);
+            BufferBuilder::observation_covariance_R::<OBSERVATIONS>().new();
+        let innovation_vector = BufferBuilder::innovation_vector_y::<OBSERVATIONS>().new();
         let residual_covariance_matrix =
-            BufferBuilder::innovation_covariance_S::<OBSERVATIONS>().new(zero);
-        let kalman_gain = BufferBuilder::kalman_gain_K::<STATES, OBSERVATIONS>().new(zero);
+            BufferBuilder::innovation_covariance_S::<OBSERVATIONS>().new();
+        let kalman_gain = BufferBuilder::kalman_gain_K::<STATES, OBSERVATIONS>().new();
 
         // Observation temporaries.
-        let temp_s_inverted = BufferBuilder::temp_S_inv::<OBSERVATIONS>().new(zero);
-        let temp_hp = BufferBuilder::temp_HP::<OBSERVATIONS, STATES>().new(zero);
-        let temp_pht = BufferBuilder::temp_PHt::<STATES, OBSERVATIONS>().new(zero);
-        let temp_khp = BufferBuilder::temp_KHP::<STATES>().new(zero);
+        let temp_s_inverted = BufferBuilder::temp_S_inv::<OBSERVATIONS>().new();
+        let temp_hp = BufferBuilder::temp_HP::<OBSERVATIONS, STATES>().new();
+        let temp_pht = BufferBuilder::temp_PHt::<STATES, OBSERVATIONS>().new();
+        let temp_khp = BufferBuilder::temp_KHP::<STATES>().new();
 
         ObservationBuilder::new::<STATES, OBSERVATIONS, T>(
             observation_matrix,

--- a/crates/minikalman/src/kalman_builder.rs
+++ b/crates/minikalman/src/kalman_builder.rs
@@ -26,7 +26,7 @@ impl<const STATES: usize, T> Default for KalmanFilterBuilder<STATES, T> {
 
 /// The type of Kalman filters with owned buffers.
 ///
-/// See also the [`KalmanFilter`](minikalman::kalman::KalmanFilter) trait.
+/// See also the [`KalmanFilter`](crate::kalman::KalmanFilter) trait.
 pub type KalmanFilterType<const STATES: usize, T> = Kalman<
     STATES,
     T,
@@ -101,7 +101,7 @@ impl<const STATES: usize, T> Default for KalmanFilterControlBuilder<STATES, T> {
 
 /// The type of Kalman filter controls with owned buffers.
 ///
-/// See also the [`KalmanFilterControl`](minikalman::kalman::KalmanFilterControl) trait.
+/// See also the [`KalmanFilterControl`](crate::kalman::KalmanFilterControl) trait.
 pub type KalmanFilterControlType<const STATES: usize, const CONTROLS: usize, T> = Control<
     STATES,
     CONTROLS,
@@ -162,7 +162,7 @@ impl<const STATES: usize, T> Default for KalmanFilterObservationBuilder<STATES, 
 
 /// The type of Kalman filter measurement / observation with owned buffers.
 ///
-/// See also the [`KalmanFilterObservation`](minikalman::kalman::KalmanFilterObservation) trait.
+/// See also the [`KalmanFilterObservation`](crate::kalman::KalmanFilterObservation) trait.
 pub type KalmanFilterObservationType<const STATES: usize, const OBSERVATIONS: usize, T> =
     Observation<
         STATES,

--- a/crates/minikalman/src/lib.rs
+++ b/crates/minikalman/src/lib.rs
@@ -145,6 +145,7 @@
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 extern crate alloc;
+extern crate core;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]

--- a/crates/minikalman/src/lib.rs
+++ b/crates/minikalman/src/lib.rs
@@ -161,7 +161,7 @@ mod static_macros;
 #[cfg(test)]
 mod test_dummies;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "alloc"))]
 mod test_filter;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
@@ -194,6 +194,12 @@ pub mod prelude {
 
     pub use crate::kalman::*;
     pub use crate::matrix::*;
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub use crate::kalman_builder::{
+        KalmanFilterControlType, KalmanFilterObservationType, KalmanFilterType,
+    };
 
     pub use crate::{
         impl_buffer_A, impl_buffer_B, impl_buffer_H, impl_buffer_K, impl_buffer_P, impl_buffer_Q,

--- a/crates/minikalman/src/lib.rs
+++ b/crates/minikalman/src/lib.rs
@@ -76,6 +76,7 @@
 //! to `static mut` variables.
 //!
 //! ```
+//! # #![allow(non_snake_case)]
 //! use minikalman::buffers::types::*;
 //! use minikalman::prelude::*;
 //!

--- a/crates/minikalman/src/lib.rs
+++ b/crates/minikalman/src/lib.rs
@@ -161,6 +161,9 @@ mod static_macros;
 #[cfg(test)]
 mod test_dummies;
 
+#[cfg(test)]
+mod test_filter;
+
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[cfg(feature = "alloc")]
 pub use crate::buffers::builder::BufferBuilder;

--- a/crates/minikalman/src/matrix/data.rs
+++ b/crates/minikalman/src/matrix/data.rs
@@ -13,8 +13,7 @@ impl MatrixData {
     where
         T: Default,
     {
-        let nothing = [T::default(); 0];
-        MatrixDataArray::<0, 0, 0, T>(nothing)
+        MatrixDataArray::<0, 0, 0, T>([])
     }
 
     /// Creates a new matrix buffer that owns the data.

--- a/crates/minikalman/src/matrix/traits.rs
+++ b/crates/minikalman/src/matrix/traits.rs
@@ -863,6 +863,7 @@ pub trait MatrixMut<const ROWS: usize, const COLS: usize, T = f32>:
 {
     /// Sets all elements of the matrix to the zero.
     #[doc(alias = "fill")]
+    #[inline(always)]
     fn clear(&mut self)
     where
         T: Copy + Zero,
@@ -888,11 +889,24 @@ pub trait MatrixMut<const ROWS: usize, const COLS: usize, T = f32>:
     /// ## Arguments
     /// * `value` - The value to set the elements to.
     #[doc(alias = "fill")]
+    #[inline(always)]
     fn set_all(&mut self, value: T)
     where
         T: Copy,
     {
         self.as_mut().fill(value);
+    }
+
+    /// Sets all elements of the matrix to the provided value.
+    ///
+    /// ## Arguments
+    /// * `value` - The value to set the elements to.
+    #[inline(always)]
+    fn set_zero(&mut self)
+    where
+        T: Copy + Zero,
+    {
+        self.set_all(T::zero())
     }
 
     /// Sets matrix elements in a symmetric matrix

--- a/crates/minikalman/src/observations.rs
+++ b/crates/minikalman/src/observations.rs
@@ -826,9 +826,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::test_dummies::{Dummy, DummyMatrix};
-
     use super::*;
+    use crate::test_dummies::make_dummy_observation;
 
     #[test]
     #[cfg(feature = "alloc")]
@@ -885,20 +884,11 @@ mod tests {
 
     #[test]
     fn builder_simple() {
-        let measurement = ObservationBuilder::new::<3, 1, f32>(
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-            Dummy::default(),
-        );
+        let measurement = make_dummy_observation();
 
         let mut measurement = trait_impl(measurement);
+        assert_eq!(measurement.states(), 3);
+        assert_eq!(measurement.observations(), 1);
 
         let test_fn = || 42;
 
@@ -928,153 +918,5 @@ mod tests {
         measurement.measurement_noise_covariance_inspect_mut(|_mat| test_fn_mut());
         measurement.measurement_noise_covariance_apply(|_mat| test_fn());
         measurement.measurement_noise_covariance_apply_mut(|_mat| test_fn_mut());
-    }
-
-    impl<const STATES: usize, T> MeasurementVector<STATES, T> for Dummy<T> {
-        type Target = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-
-    impl<const STATES: usize, T> MeasurementVectorMut<STATES, T> for Dummy<T> {
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-
-    impl<const OBSERVATIONS: usize, const STATES: usize, T>
-        ObservationMatrix<OBSERVATIONS, STATES, T> for Dummy<T>
-    {
-        type Target = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-
-    impl<const OBSERVATIONS: usize, const STATES: usize, T>
-        ObservationMatrixMut<OBSERVATIONS, STATES, T> for Dummy<T>
-    {
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-
-    impl<const OBSERVATIONS: usize, T> MeasurementNoiseCovarianceMatrix<OBSERVATIONS, T> for Dummy<T> {
-        type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::TargetMut {
-            &self.0
-        }
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-
-    impl<const OBSERVATIONS: usize, T> InnovationVector<OBSERVATIONS, T> for Dummy<T> {
-        type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-
-    impl<const OBSERVATIONS: usize, T> InnovationCovarianceMatrix<OBSERVATIONS, T> for Dummy<T> {
-        type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-
-    impl<const STATES: usize, const OBSERVATIONS: usize, T>
-        KalmanGainMatrix<STATES, OBSERVATIONS, T> for Dummy<T>
-    {
-        type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-
-    impl<const OBSERVATIONS: usize, T> TemporaryResidualCovarianceInvertedMatrix<OBSERVATIONS, T>
-        for Dummy<T>
-    {
-        type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-
-    impl<const OBSERVATIONS: usize, const STATES: usize, T>
-        TemporaryHPMatrix<OBSERVATIONS, STATES, T> for Dummy<T>
-    {
-        type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-
-    impl<const STATES: usize, T> TemporaryKHPMatrix<STATES, T> for Dummy<T> {
-        type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
-    }
-
-    impl<const STATES: usize, const OBSERVATIONS: usize, T>
-        TemporaryPHTMatrix<STATES, OBSERVATIONS, T> for Dummy<T>
-    {
-        type Target = DummyMatrix<T>;
-        type TargetMut = DummyMatrix<T>;
-
-        fn as_matrix(&self) -> &Self::Target {
-            &self.0
-        }
-
-        fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
-            &mut self.0
-        }
     }
 }

--- a/crates/minikalman/src/observations.rs
+++ b/crates/minikalman/src/observations.rs
@@ -851,11 +851,12 @@ mod tests {
         assert_eq!(measurement.states(), STATES);
         assert_eq!(measurement.observations(), OBSERVATIONS);
 
-        let test_fn = || {};
+        let test_fn = || 42;
 
         let mut temp = 0;
         let mut test_fn_mut = || {
             temp += 0;
+            42
         };
 
         let _vec = measurement.measurement_vector_ref();
@@ -899,11 +900,12 @@ mod tests {
 
         let mut measurement = trait_impl(measurement);
 
-        let test_fn = || {};
+        let test_fn = || 42;
 
         let mut temp = 0;
         let mut test_fn_mut = || {
             temp += 0;
+            42
         };
 
         let _vec = measurement.measurement_vector_ref();

--- a/crates/minikalman/src/observations.rs
+++ b/crates/minikalman/src/observations.rs
@@ -378,50 +378,16 @@ impl<
     /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
     /// inaccuracies. It quantifies the expected variability in the measurement process.
     #[inline(always)]
-    pub fn measurement_noise_ref(&self) -> &R {
+    pub fn measurement_noise_covariance_ref(&self) -> &R {
         &self.R
     }
 
-    /// Gets a mutable reference to the measurement noise matrix R.
-    ///
-    /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
-    /// inaccuracies. It quantifies the expected variability in the measurement process.
-    #[inline(always)]
-    #[doc(alias = "kalman_get_measurement_noise")]
-    pub fn measurement_noise_mut(&mut self) -> &mut R {
-        &mut self.R
-    }
-
     /// Applies a function to the measurement noise matrix R.
     ///
     /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
     /// inaccuracies. It quantifies the expected variability in the measurement process.
     #[inline(always)]
-    pub fn measurement_noise_apply<F, O>(&mut self, mut f: F) -> O
-    where
-        F: FnMut(&mut R) -> O,
-    {
-        f(&mut self.R)
-    }
-
-    /// Applies a function to the measurement noise matrix R.
-    ///
-    /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
-    /// inaccuracies. It quantifies the expected variability in the measurement process.
-    #[inline(always)]
-    pub fn measurement_noise_apply_mut<F, O>(&mut self, f: F) -> O
-    where
-        F: Fn(&mut R) -> O,
-    {
-        f(&mut self.R)
-    }
-
-    /// Applies a function to the measurement noise matrix R.
-    ///
-    /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
-    /// inaccuracies. It quantifies the expected variability in the measurement process.
-    #[inline(always)]
-    pub fn measurement_noise_inspect<F, O>(&self, f: F) -> O
+    pub fn measurement_noise_covariance_inspect<F, O>(&self, f: F) -> O
     where
         F: Fn(&R) -> O,
     {
@@ -433,11 +399,45 @@ impl<
     /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
     /// inaccuracies. It quantifies the expected variability in the measurement process.
     #[inline(always)]
-    pub fn measurement_noise_inspect_mut<F, O>(&self, mut f: F) -> O
+    pub fn measurement_noise_covariance_inspect_mut<F, O>(&self, mut f: F) -> O
     where
         F: FnMut(&R) -> O,
     {
         f(&self.R)
+    }
+
+    /// Gets a mutable reference to the measurement noise matrix R.
+    ///
+    /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
+    /// inaccuracies. It quantifies the expected variability in the measurement process.
+    #[inline(always)]
+    #[doc(alias = "kalman_get_measurement_noise")]
+    pub fn measurement_noise_covariance_mut(&mut self) -> &mut R {
+        &mut self.R
+    }
+
+    /// Applies a function to the measurement noise matrix R.
+    ///
+    /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
+    /// inaccuracies. It quantifies the expected variability in the measurement process.
+    #[inline(always)]
+    pub fn measurement_noise_covariance_apply<F, O>(&mut self, f: F) -> O
+    where
+        F: Fn(&mut R) -> O,
+    {
+        f(&mut self.R)
+    }
+
+    /// Applies a function to the measurement noise matrix R.
+    ///
+    /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
+    /// inaccuracies. It quantifies the expected variability in the measurement process.
+    #[inline(always)]
+    pub fn measurement_noise_covariance_apply_mut<F, O>(&mut self, mut f: F) -> O
+    where
+        F: FnMut(&mut R) -> O,
+    {
+        f(&mut self.R)
     }
 }
 
@@ -753,7 +753,7 @@ where
     type MeasurementNoiseCovarianceMatrix = R;
 
     fn measurement_noise_covariance_ref(&self) -> &Self::MeasurementNoiseCovarianceMatrix {
-        self.measurement_noise_ref()
+        self.measurement_noise_covariance_ref()
     }
 }
 
@@ -781,7 +781,7 @@ where
     fn measurement_noise_covariance_mut(
         &mut self,
     ) -> &mut Self::MeasurementNoiseCovarianceMatrixMut {
-        self.measurement_noise_mut()
+        self.measurement_noise_covariance_mut()
     }
 }
 

--- a/crates/minikalman/src/observations.rs
+++ b/crates/minikalman/src/observations.rs
@@ -843,12 +843,42 @@ mod tests {
         filter.correct(&mut measurement);
     }
 
-    fn trait_impl<const STATES: usize, const OBSERVATIONS: usize, T, M>(measurement: M) -> M
+    fn trait_impl<const STATES: usize, const OBSERVATIONS: usize, T, M>(mut measurement: M) -> M
     where
-        M: KalmanFilterObservation<STATES, OBSERVATIONS, T>,
+        M: KalmanFilterObservation<STATES, OBSERVATIONS, T>
+            + KalmanFilterObservationTransformationMut<STATES, OBSERVATIONS, T>,
     {
         assert_eq!(measurement.states(), STATES);
         assert_eq!(measurement.observations(), OBSERVATIONS);
+
+        let test_fn = || {};
+
+        let mut temp = 0;
+        let mut test_fn_mut = || {
+            temp += 0;
+        };
+
+        let _vec = measurement.measurement_vector_ref();
+        let _vec = measurement.measurement_vector_mut();
+        measurement.measurement_vector_inspect(|_vec| test_fn());
+        measurement.measurement_vector_inspect_mut(|_vec| test_fn_mut());
+        measurement.measurement_vector_apply(|_vec| test_fn());
+        measurement.measurement_vector_apply_mut(|_vec| test_fn_mut());
+
+        let _mat = measurement.observation_matrix_ref();
+        let _mat = measurement.observation_matrix_mut();
+        measurement.observation_matrix_inspect(|_mat| test_fn());
+        measurement.observation_matrix_inspect_mut(|_mat| test_fn_mut());
+        measurement.observation_matrix_apply(|_mat| test_fn());
+        measurement.observation_matrix_apply_mut(|_mat| test_fn_mut());
+
+        let _mat = measurement.measurement_noise_covariance_ref();
+        let _mat = measurement.measurement_noise_covariance_mut();
+        measurement.measurement_noise_covariance_inspect(|_mat| test_fn());
+        measurement.measurement_noise_covariance_inspect_mut(|_mat| test_fn_mut());
+        measurement.measurement_noise_covariance_apply(|_mat| test_fn());
+        measurement.measurement_noise_covariance_apply_mut(|_mat| test_fn_mut());
+
         measurement
     }
 

--- a/crates/minikalman/src/observations.rs
+++ b/crates/minikalman/src/observations.rs
@@ -303,11 +303,29 @@ impl<
     /// }
     /// ```
     #[inline(always)]
-    pub fn measurement_vector_apply<F>(&mut self, mut f: F)
+    pub fn measurement_vector_apply<F, O>(&mut self, mut f: F) -> O
     where
-        F: FnMut(&mut Z),
+        F: FnMut(&mut Z) -> O,
     {
         f(&mut self.z)
+    }
+
+    /// Applies a function to the measurement vector z.
+    #[inline(always)]
+    pub fn measurement_vector_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&Z) -> O,
+    {
+        f(&self.z)
+    }
+
+    /// Applies a function to the measurement vector z.
+    #[inline(always)]
+    pub fn measurement_vector_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&Z) -> O,
+    {
+        f(&self.z)
     }
 
     /// Gets a reference to the measurement transformation matrix H.
@@ -318,6 +336,32 @@ impl<
     #[inline(always)]
     pub fn observation_matrix_ref(&self) -> &H {
         &self.H
+    }
+
+    /// Applies a function to the measurement transformation matrix H.
+    ///
+    /// This matrix maps the state vector into the measurement space, relating the state of the
+    /// system to the observations or measurements. It defines how each state component contributes
+    /// to the measurement.
+    #[inline(always)]
+    pub fn observation_matrix_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&H) -> O,
+    {
+        f(&self.H)
+    }
+
+    /// Applies a function to the measurement transformation matrix H.
+    ///
+    /// This matrix maps the state vector into the measurement space, relating the state of the
+    /// system to the observations or measurements. It defines how each state component contributes
+    /// to the measurement.
+    #[inline(always)]
+    pub fn observation_matrix_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&H) -> O,
+    {
+        f(&self.H)
     }
 
     /// Gets a reference to the process noise matrix R.
@@ -344,11 +388,35 @@ impl<
     /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
     /// inaccuracies. It quantifies the expected variability in the measurement process.
     #[inline(always)]
-    pub fn process_noise_apply<F>(&mut self, mut f: F)
+    pub fn process_noise_apply<F, O>(&mut self, mut f: F) -> O
     where
-        F: FnMut(&mut R),
+        F: FnMut(&mut R) -> O,
     {
         f(&mut self.R)
+    }
+
+    /// Applies a function to the process noise matrix R.
+    ///
+    /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
+    /// inaccuracies. It quantifies the expected variability in the measurement process.
+    #[inline(always)]
+    pub fn process_noise_inspect<F, O>(&self, f: F) -> O
+    where
+        F: Fn(&R) -> O,
+    {
+        f(&self.R)
+    }
+
+    /// Applies a function to the process noise matrix R.
+    ///
+    /// This matrix represents the uncertainty in the measurements, accounting for sensor noise and
+    /// inaccuracies. It quantifies the expected variability in the measurement process.
+    #[inline(always)]
+    pub fn process_noise_inspect_mut<F, O>(&self, mut f: F) -> O
+    where
+        F: FnMut(&R) -> O,
+    {
+        f(&self.R)
     }
 }
 
@@ -479,9 +547,9 @@ where
     /// system to the observations or measurements. It defines how each state component contributes
     /// to the measurement.
     #[inline(always)]
-    pub fn observation_matrix_apply<F>(&mut self, mut f: F)
+    pub fn observation_matrix_apply<F, O>(&mut self, mut f: F) -> O
     where
-        F: FnMut(&mut H),
+        F: FnMut(&mut H) -> O,
     {
         f(&mut self.H)
     }

--- a/crates/minikalman/src/test_dummies.rs
+++ b/crates/minikalman/src/test_dummies.rs
@@ -1,13 +1,65 @@
-use crate::matrix::{Matrix, MatrixMut};
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 
+use crate::kalman::*;
+use crate::matrix::{Matrix, MatrixMut};
+use crate::{Control, ControlBuilder, Kalman, KalmanBuilder, Observation, ObservationBuilder};
+
+pub fn make_dummy_filter(
+) -> Kalman<3, f32, Dummy<f32>, Dummy<f32>, Dummy<f32>, Dummy<f32>, Dummy<f32>> {
+    KalmanBuilder::new::<3, f32>(
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+    )
+}
+
+pub fn make_dummy_control() -> Control<3, 2, f32, Dummy<f32>, Dummy<f32>, Dummy<f32>, Dummy<f32>> {
+    ControlBuilder::new::<3, 2, f32>(
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+    )
+}
+
+pub fn make_dummy_observation() -> Observation<
+    3,
+    1,
+    f32,
+    Dummy<f32>,
+    Dummy<f32>,
+    Dummy<f32>,
+    Dummy<f32>,
+    Dummy<f32>,
+    Dummy<f32>,
+    Dummy<f32>,
+    Dummy<f32>,
+    Dummy<f32>,
+    Dummy<f32>,
+> {
+    ObservationBuilder::new::<3, 1, f32>(
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+        Dummy::default(),
+    )
+}
+
 /// A dummy buffer type that holds a [`DummyMatrix`]
-#[derive(Default)]
+#[derive(Default, Copy, Clone)]
 pub struct Dummy<T>(pub DummyMatrix<T>, PhantomData<T>);
 
 /// A dummy matrix that is arbitrarily shaped.
-#[derive(Default)]
+#[derive(Default, Copy, Clone)]
 pub struct DummyMatrix<T>(PhantomData<T>);
 
 impl<T> AsRef<[T]> for Dummy<T> {
@@ -65,3 +117,284 @@ impl<T> IndexMut<usize> for DummyMatrix<T> {
 impl<const ROWS: usize, const COLS: usize, T> Matrix<ROWS, COLS, T> for DummyMatrix<T> {}
 
 impl<const ROWS: usize, const COLS: usize, T> MatrixMut<ROWS, COLS, T> for DummyMatrix<T> {}
+
+impl<const STATES: usize, T> StateVector<STATES, T> for Dummy<T> {
+    type Target = DummyMatrix<T>;
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const STATES: usize, T> StateVectorMut<STATES, T> for Dummy<T> {
+    type TargetMut = DummyMatrix<T>;
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const STATES: usize, T> StateTransitionMatrix<STATES, T> for Dummy<T> {
+    type Target = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const STATES: usize, T> StateTransitionMatrixMut<STATES, T> for Dummy<T> {
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const STATES: usize, T> EstimateCovarianceMatrix<STATES, T> for Dummy<T> {
+    type Target = DummyMatrix<T>;
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const STATES: usize, T> PredictedStateEstimateVector<STATES, T> for Dummy<T> {
+    type Target = DummyMatrix<T>;
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const STATES: usize, T> TemporaryStateMatrix<STATES, T> for Dummy<T> {
+    type Target = DummyMatrix<T>;
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const CONTROLS: usize, T> ControlVector<CONTROLS, T> for Dummy<T> {
+    type Target = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl<const CONTROLS: usize, T> ControlVectorMut<CONTROLS, T> for Dummy<T> {
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+impl<const STATES: usize, const CONTROLS: usize, T> ControlMatrix<STATES, CONTROLS, T>
+    for Dummy<T>
+{
+    type Target = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const STATES: usize, const CONTROLS: usize, T> ControlMatrixMut<STATES, CONTROLS, T>
+    for Dummy<T>
+{
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const CONTROLS: usize, T> ProcessNoiseCovarianceMatrix<CONTROLS, T> for Dummy<T> {
+    type Target = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const CONTROLS: usize, T> ProcessNoiseCovarianceMatrixMut<CONTROLS, T> for Dummy<T> {
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const STATES: usize, const CONTROLS: usize, T> TemporaryBQMatrix<STATES, CONTROLS, T>
+    for Dummy<T>
+{
+    type Target = DummyMatrix<T>;
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const STATES: usize, T> MeasurementVector<STATES, T> for Dummy<T> {
+    type Target = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const STATES: usize, T> MeasurementVectorMut<STATES, T> for Dummy<T> {
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const OBSERVATIONS: usize, const STATES: usize, T> ObservationMatrix<OBSERVATIONS, STATES, T>
+    for Dummy<T>
+{
+    type Target = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const OBSERVATIONS: usize, const STATES: usize, T>
+    ObservationMatrixMut<OBSERVATIONS, STATES, T> for Dummy<T>
+{
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const OBSERVATIONS: usize, T> MeasurementNoiseCovarianceMatrix<OBSERVATIONS, T> for Dummy<T> {
+    type Target = DummyMatrix<T>;
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::TargetMut {
+        &self.0
+    }
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const OBSERVATIONS: usize, T> InnovationVector<OBSERVATIONS, T> for Dummy<T> {
+    type Target = DummyMatrix<T>;
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const OBSERVATIONS: usize, T> InnovationCovarianceMatrix<OBSERVATIONS, T> for Dummy<T> {
+    type Target = DummyMatrix<T>;
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const STATES: usize, const OBSERVATIONS: usize, T> KalmanGainMatrix<STATES, OBSERVATIONS, T>
+    for Dummy<T>
+{
+    type Target = DummyMatrix<T>;
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const OBSERVATIONS: usize, T> TemporaryResidualCovarianceInvertedMatrix<OBSERVATIONS, T>
+    for Dummy<T>
+{
+    type Target = DummyMatrix<T>;
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const OBSERVATIONS: usize, const STATES: usize, T> TemporaryHPMatrix<OBSERVATIONS, STATES, T>
+    for Dummy<T>
+{
+    type Target = DummyMatrix<T>;
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const STATES: usize, T> TemporaryKHPMatrix<STATES, T> for Dummy<T> {
+    type Target = DummyMatrix<T>;
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}
+
+impl<const STATES: usize, const OBSERVATIONS: usize, T> TemporaryPHTMatrix<STATES, OBSERVATIONS, T>
+    for Dummy<T>
+{
+    type Target = DummyMatrix<T>;
+    type TargetMut = DummyMatrix<T>;
+
+    fn as_matrix(&self) -> &Self::Target {
+        &self.0
+    }
+
+    fn as_matrix_mut(&mut self) -> &mut Self::TargetMut {
+        &mut self.0
+    }
+}

--- a/crates/minikalman/src/test_dummies.rs
+++ b/crates/minikalman/src/test_dummies.rs
@@ -55,12 +55,12 @@ pub fn make_dummy_observation() -> Observation<
 }
 
 /// A dummy buffer type that holds a [`DummyMatrix`]
-#[derive(Default, Copy, Clone)]
+#[derive(Default)]
 pub struct Dummy<T>(pub DummyMatrix<T>, PhantomData<T>);
 
 /// A dummy matrix that is arbitrarily shaped.
-#[derive(Default, Copy, Clone)]
-pub struct DummyMatrix<T>(PhantomData<T>);
+#[derive(Default)]
+pub struct DummyMatrix<T>([T; 9], PhantomData<T>);
 
 impl<T> AsRef<[T]> for Dummy<T> {
     fn as_ref(&self) -> &[T] {
@@ -90,27 +90,27 @@ impl<T> IndexMut<usize> for Dummy<T> {
 
 impl<T> AsRef<[T]> for DummyMatrix<T> {
     fn as_ref(&self) -> &[T] {
-        unimplemented!("A dummy matrix cannot actually dereference into data")
+        self.0.as_ref()
     }
 }
 
 impl<T> AsMut<[T]> for DummyMatrix<T> {
     fn as_mut(&mut self) -> &mut [T] {
-        unimplemented!("A dummy matrix cannot actually dereference into data")
+        self.0.as_mut()
     }
 }
 
 impl<T> Index<usize> for DummyMatrix<T> {
     type Output = T;
 
-    fn index(&self, _index: usize) -> &Self::Output {
-        unimplemented!("A dummy matrix cannot actually index into data")
+    fn index(&self, index: usize) -> &Self::Output {
+        self.0.index(index)
     }
 }
 
 impl<T> IndexMut<usize> for DummyMatrix<T> {
-    fn index_mut(&mut self, _index: usize) -> &mut Self::Output {
-        unimplemented!("A dummy matrix cannot actually index into data")
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        self.0.index_mut(index)
     }
 }
 

--- a/crates/minikalman/src/test_filter.rs
+++ b/crates/minikalman/src/test_filter.rs
@@ -1,6 +1,69 @@
-#[allow(unused)]
-pub fn create_test_filter() {
-    const NUM_STATES: usize = 3;
+use crate::builder::KalmanFilterBuilder;
+use crate::prelude::*;
 
-    // TODO
+pub struct TestFilter {
+    pub filter: KalmanFilterType<3, f32>,
+    pub control: KalmanFilterControlType<3, 1, f32>,
+    pub measurement: KalmanFilterObservationType<3, 1, f32>,
+}
+
+#[allow(unused)]
+pub fn create_test_filter(delta_t: f32) -> TestFilter {
+    let builder = KalmanFilterBuilder::<3, f32>::default();
+    let mut filter = builder.build();
+
+    let controls = builder.controls();
+    let mut control = controls.build::<1>();
+
+    let measurements = builder.observations();
+    let mut measurement = measurements.build::<1>();
+
+    // Simple model of linear motion.
+    filter.state_transition_apply(|mat| {
+        mat.set(0, 0, 1.0);
+        mat.set(0, 1, delta_t);
+        mat.set(0, 2, 0.5 * delta_t * delta_t);
+
+        mat.set(1, 0, 0.0);
+        mat.set(1, 1, 1.0);
+        mat.set(1, 2, delta_t);
+
+        mat.set(2, 0, 0.0);
+        mat.set(2, 1, 0.0);
+        mat.set(2, 2, 1.0);
+    });
+
+    // No state estimate so far.
+    filter.state_vector_mut().set_zero();
+
+    // Estimate covariance is identity.
+    filter.estimate_covariance_mut().make_scalar(0.1);
+
+    // Control input directly affects the acceleration and, over the time step,
+    // the velocity and position.
+    control.control_matrix_apply(|mat| {
+        mat.set(0, 0, 0.5 * delta_t * delta_t);
+        mat.set(1, 0, delta_t);
+        mat.set(2, 0, 1.0);
+    });
+
+    // No control inputs now.
+    control.control_vector_mut().set_zero();
+
+    // Process noise is identity.
+    control.process_noise_covariance_mut().make_identity();
+
+    // The measurement is an average of the states.
+    measurement.observation_matrix_mut().set_all(1.0 / 3.0);
+
+    // Measurement noise covariance is identity.
+    measurement
+        .measurement_noise_covariance_mut()
+        .make_identity();
+
+    TestFilter {
+        filter,
+        control,
+        measurement,
+    }
 }

--- a/crates/minikalman/src/test_filter.rs
+++ b/crates/minikalman/src/test_filter.rs
@@ -1,0 +1,6 @@
+#[allow(unused)]
+pub fn create_test_filter() {
+    const NUM_STATES: usize = 3;
+
+    // TODO
+}

--- a/crates/minikalman/tests/gravity.rs
+++ b/crates/minikalman/tests/gravity.rs
@@ -85,7 +85,9 @@ fn test_gravity_estimation() {
     initialize_state_transition_matrix(filter.state_transition_mut());
     initialize_state_covariance_matrix(filter.estimate_covariance_mut());
     initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-    initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
+    initialize_position_measurement_process_noise_matrix(
+        measurement.measurement_noise_covariance_mut(),
+    );
 
     // Filter!
     for t in 0..REAL_DISTANCE.len() {

--- a/crates/minikalman/tests/gravity.rs
+++ b/crates/minikalman/tests/gravity.rs
@@ -85,7 +85,7 @@ fn test_gravity_estimation() {
     initialize_state_transition_matrix(filter.state_transition_mut());
     initialize_state_covariance_matrix(filter.estimate_covariance_mut());
     initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-    initialize_position_measurement_process_noise_matrix(measurement.process_noise_mut());
+    initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
 
     // Filter!
     for t in 0..REAL_DISTANCE.len() {

--- a/crates/minikalman/tests/gravity_q_tuned.rs
+++ b/crates/minikalman/tests/gravity_q_tuned.rs
@@ -85,7 +85,9 @@ fn test_gravity_estimation_tuned() {
     initialize_state_transition_matrix(filter.state_transition_mut());
     initialize_state_covariance_matrix(filter.estimate_covariance_mut());
     initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-    initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
+    initialize_position_measurement_process_noise_matrix(
+        measurement.measurement_noise_covariance_mut(),
+    );
 
     const LAMBDA: f64 = 0.5;
 

--- a/crates/minikalman/tests/gravity_q_tuned.rs
+++ b/crates/minikalman/tests/gravity_q_tuned.rs
@@ -85,7 +85,7 @@ fn test_gravity_estimation_tuned() {
     initialize_state_transition_matrix(filter.state_transition_mut());
     initialize_state_covariance_matrix(filter.estimate_covariance_mut());
     initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-    initialize_position_measurement_process_noise_matrix(measurement.process_noise_mut());
+    initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
 
     const LAMBDA: f64 = 0.5;
 

--- a/xbuild-tests/stm32/src/kalman_fixed_example.rs
+++ b/xbuild-tests/stm32/src/kalman_fixed_example.rs
@@ -144,7 +144,9 @@ pub fn predict_gravity() -> I16F16 {
     initialize_state_transition_matrix(filter.state_transition_mut());
     initialize_state_covariance_matrix(filter.estimate_covariance_mut());
     initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-    initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
+    initialize_position_measurement_process_noise_matrix(
+        measurement.measurement_noise_covariance_mut(),
+    );
 
     // Filter!
     for t in 0..REAL_DISTANCE.len() {

--- a/xbuild-tests/stm32/src/kalman_fixed_example.rs
+++ b/xbuild-tests/stm32/src/kalman_fixed_example.rs
@@ -144,7 +144,7 @@ pub fn predict_gravity() -> I16F16 {
     initialize_state_transition_matrix(filter.state_transition_mut());
     initialize_state_covariance_matrix(filter.estimate_covariance_mut());
     initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-    initialize_position_measurement_process_noise_matrix(measurement.process_noise_mut());
+    initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
 
     // Filter!
     for t in 0..REAL_DISTANCE.len() {

--- a/xbuild-tests/stm32/src/kalman_float_example.rs
+++ b/xbuild-tests/stm32/src/kalman_float_example.rs
@@ -84,7 +84,7 @@ pub fn predict_gravity() -> f32 {
     initialize_state_transition_matrix(filter.state_transition_mut());
     initialize_state_covariance_matrix(filter.estimate_covariance_mut());
     initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-    initialize_position_measurement_process_noise_matrix(measurement.process_noise_mut());
+    initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
 
     // Filter!
     for t in 0..REAL_DISTANCE.len() {

--- a/xbuild-tests/stm32/src/kalman_float_example.rs
+++ b/xbuild-tests/stm32/src/kalman_float_example.rs
@@ -84,7 +84,9 @@ pub fn predict_gravity() -> f32 {
     initialize_state_transition_matrix(filter.state_transition_mut());
     initialize_state_covariance_matrix(filter.estimate_covariance_mut());
     initialize_position_measurement_transformation_matrix(measurement.observation_matrix_mut());
-    initialize_position_measurement_process_noise_matrix(measurement.measurement_noise_mut());
+    initialize_position_measurement_process_noise_matrix(
+        measurement.measurement_noise_covariance_mut(),
+    );
 
     // Filter!
     for t in 0..REAL_DISTANCE.len() {


### PR DESCRIPTION
This removes the `KalmanFilterNumObservations<OBSERVATIONS>` and `KalmanFilterNumControls<CONTROLS>` trait bounds from the `control` and `correct` functions.