### PR TITLE
Remove apply_mut and inspect_mut in favor of apply and inspect

### DIFF
--- a/crates/minikalman/src/controls.rs
+++ b/crates/minikalman/src/controls.rs
@@ -380,7 +380,7 @@ mod tests {
         let mut control = ControlBuilder::new::<NUM_STATES, NUM_CONTROLS, f32>(B, u, Q, temp_BQ);
 
         // State transition is identity.
-        filter.state_transition_mut().apply_mut(|mat| {
+        filter.state_transition_mut().apply(|mat| {
             mat[0] = 1.0;
             mat[1] = 1.0;
             mat[2] = 1.0;
@@ -392,7 +392,7 @@ mod tests {
         });
 
         // State covariance is identity.
-        filter.estimate_covariance_mut().apply_mut(|mat| {
+        filter.estimate_covariance_mut().apply(|mat| {
             mat[0] = 1.0;
             mat[NUM_STATES + 1] = 1.0;
             mat[2 * NUM_STATES + 2] = 1.0;
@@ -400,21 +400,21 @@ mod tests {
         });
 
         // Control applies linearly to state.
-        control.control_matrix_mut().apply_mut(|mat| {
+        control.control_matrix_mut().apply(|mat| {
             mat[NUM_CONTROLS] = 1.0;
             mat[2 * NUM_CONTROLS + 1] = 1.0;
             mat[3 * NUM_CONTROLS + 2] = 1.0;
         });
 
         // Control covariance is identity.
-        control.process_noise_covariance_mut().apply_mut(|mat| {
+        control.process_noise_covariance_mut().apply(|mat| {
             mat[0] = 1.0;
             mat[NUM_CONTROLS + 1] = 1.0;
             mat[2 * NUM_CONTROLS + 2] = 1.0;
         });
 
         // Define some test control vector.
-        control.control_vector_mut().apply_mut(|vec| {
+        control.control_vector_mut().apply(|vec| {
             vec.set(0, 0, 0.1);
             vec.set(1, 0, 1.0);
             vec.set(2, 0, 10.0);
@@ -484,7 +484,7 @@ mod tests {
         let _ = control
             .control_vector()
             .as_matrix()
-            .inspect_mut(|_vec| test_fn_mut());
+            .inspect(|_vec| test_fn_mut());
         control
             .control_vector_mut()
             .as_matrix_mut()
@@ -492,7 +492,7 @@ mod tests {
         control
             .control_vector_mut()
             .as_matrix_mut()
-            .apply_mut(|_vec| test_fn_mut());
+            .apply(|_vec| test_fn_mut());
 
         let _mat = control.control_matrix();
         let _mat = control.control_matrix_mut();
@@ -503,7 +503,7 @@ mod tests {
         let _ = control
             .control_matrix()
             .as_matrix()
-            .inspect_mut(|_mat| test_fn_mut());
+            .inspect(|_mat| test_fn_mut());
         control
             .control_matrix_mut()
             .as_matrix_mut()
@@ -511,7 +511,7 @@ mod tests {
         control
             .control_matrix_mut()
             .as_matrix_mut()
-            .apply_mut(|_mat| test_fn_mut());
+            .apply(|_mat| test_fn_mut());
 
         let _mat = control.process_noise_covariance();
         let _mat = control.process_noise_covariance_mut();
@@ -522,7 +522,7 @@ mod tests {
         let _ = control
             .process_noise_covariance()
             .as_matrix()
-            .inspect_mut(|_mat| test_fn_mut());
+            .inspect(|_mat| test_fn_mut());
         control
             .process_noise_covariance_mut()
             .as_matrix_mut()
@@ -530,7 +530,7 @@ mod tests {
         control
             .process_noise_covariance_mut()
             .as_matrix_mut()
-            .apply_mut(|_mat| test_fn_mut());
+            .apply(|_mat| test_fn_mut());
 
         control
     }
@@ -560,7 +560,7 @@ mod tests {
         let _ = control
             .control_vector()
             .as_matrix()
-            .inspect_mut(|_vec| test_fn_mut());
+            .inspect(|_vec| test_fn_mut());
         control
             .control_vector_mut()
             .as_matrix_mut()
@@ -568,7 +568,7 @@ mod tests {
         control
             .control_vector_mut()
             .as_matrix_mut()
-            .apply_mut(|_vec| test_fn_mut());
+            .apply(|_vec| test_fn_mut());
 
         let _mat = control.control_matrix();
         let _mat = control.control_matrix_mut();
@@ -579,7 +579,7 @@ mod tests {
         let _ = control
             .control_matrix()
             .as_matrix()
-            .inspect_mut(|_mat| test_fn_mut());
+            .inspect(|_mat| test_fn_mut());
         control
             .control_matrix_mut()
             .as_matrix_mut()
@@ -587,7 +587,7 @@ mod tests {
         control
             .control_matrix_mut()
             .as_matrix_mut()
-            .apply_mut(|_mat| test_fn_mut());
+            .apply(|_mat| test_fn_mut());
 
         let _mat = control.process_noise_covariance();
         let _mat = control.process_noise_covariance_mut();
@@ -598,7 +598,7 @@ mod tests {
         let _ = control
             .process_noise_covariance()
             .as_matrix()
-            .inspect_mut(|_mat| test_fn_mut());
+            .inspect(|_mat| test_fn_mut());
         control
             .process_noise_covariance_mut()
             .as_matrix_mut()
@@ -606,6 +606,6 @@ mod tests {
         control
             .process_noise_covariance_mut()
             .as_matrix_mut()
-            .apply_mut(|_mat| test_fn_mut());
+            .apply(|_mat| test_fn_mut());
     }
 }

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -931,7 +931,7 @@ mod tests {
         let _ = filter
             .state_vector_mut()
             .as_matrix()
-            .inspect_mut(|_vec| test_fn_mut());
+            .inspect(|_vec| test_fn_mut());
         filter
             .state_vector_mut()
             .as_matrix_mut()
@@ -939,7 +939,7 @@ mod tests {
         filter
             .state_vector_mut()
             .as_matrix_mut()
-            .apply_mut(|_vec| test_fn_mut());
+            .apply(|_vec| test_fn_mut());
 
         let _mat = filter.state_transition();
         let _mat = filter.state_transition_mut();
@@ -950,7 +950,7 @@ mod tests {
         let _ = filter
             .state_transition_mut()
             .as_matrix()
-            .inspect_mut(|_mat| test_fn_mut());
+            .inspect(|_mat| test_fn_mut());
         filter
             .state_transition_mut()
             .as_matrix_mut()
@@ -958,7 +958,7 @@ mod tests {
         filter
             .state_transition_mut()
             .as_matrix_mut()
-            .apply_mut(|_mat| test_fn_mut());
+            .apply(|_mat| test_fn_mut());
 
         let _mat = filter.estimate_covariance();
         let _mat = filter.estimate_covariance_mut();
@@ -969,7 +969,7 @@ mod tests {
         let _ = filter
             .estimate_covariance_mut()
             .as_matrix()
-            .inspect_mut(|_mat| test_fn_mut());
+            .inspect(|_mat| test_fn_mut());
         filter
             .estimate_covariance_mut()
             .as_matrix_mut()
@@ -977,7 +977,7 @@ mod tests {
         filter
             .estimate_covariance_mut()
             .as_matrix_mut()
-            .apply_mut(|_mat| test_fn_mut());
+            .apply(|_mat| test_fn_mut());
 
         filter.predict();
 
@@ -1013,7 +1013,7 @@ mod tests {
         let _ = filter
             .state_vector_mut()
             .as_matrix()
-            .inspect_mut(|_vec| test_fn_mut());
+            .inspect(|_vec| test_fn_mut());
         filter
             .state_vector_mut()
             .as_matrix_mut()
@@ -1021,7 +1021,7 @@ mod tests {
         filter
             .state_vector_mut()
             .as_matrix_mut()
-            .apply_mut(|_vec| test_fn_mut());
+            .apply(|_vec| test_fn_mut());
 
         let _mat = filter.state_transition();
         let _mat = filter.state_transition_mut();
@@ -1032,7 +1032,7 @@ mod tests {
         let _ = filter
             .state_transition_mut()
             .as_matrix()
-            .inspect_mut(|_mat| test_fn_mut());
+            .inspect(|_mat| test_fn_mut());
         filter
             .state_transition_mut()
             .as_matrix_mut()
@@ -1040,7 +1040,7 @@ mod tests {
         filter
             .state_transition_mut()
             .as_matrix_mut()
-            .apply_mut(|_mat| test_fn_mut());
+            .apply(|_mat| test_fn_mut());
 
         let _mat = filter.estimate_covariance();
         let _mat = filter.estimate_covariance_mut();
@@ -1051,7 +1051,7 @@ mod tests {
         let _ = filter
             .estimate_covariance_mut()
             .as_matrix()
-            .inspect_mut(|_mat| test_fn_mut());
+            .inspect(|_mat| test_fn_mut());
         filter
             .estimate_covariance_mut()
             .as_matrix_mut()
@@ -1059,7 +1059,7 @@ mod tests {
         filter
             .estimate_covariance_mut()
             .as_matrix_mut()
-            .apply_mut(|_mat| test_fn_mut());
+            .apply(|_mat| test_fn_mut());
 
         filter.predict();
     }

--- a/crates/minikalman/src/matrix/traits.rs
+++ b/crates/minikalman/src/matrix/traits.rs
@@ -57,16 +57,7 @@ pub trait Matrix<const ROWS: usize, const COLS: usize, T = f32>:
 
     /// Applies a function to this matrix.
     #[inline(always)]
-    fn inspect<F, O>(&self, f: F) -> O
-    where
-        F: Fn(&Self) -> O,
-    {
-        f(self)
-    }
-
-    /// Applies a function to this matrix.
-    #[inline(always)]
-    fn inspect_mut<F, O>(&self, mut f: F) -> O
+    fn inspect<F, O>(&self, mut f: F) -> O
     where
         F: FnMut(&Self) -> O,
     {
@@ -893,16 +884,7 @@ pub trait MatrixMut<const ROWS: usize, const COLS: usize, T = f32>:
 {
     /// Applies a function to this matrix.
     #[inline(always)]
-    fn apply<F, O>(&mut self, f: F) -> O
-    where
-        F: Fn(&mut Self) -> O,
-    {
-        f(self)
-    }
-
-    /// Applies a function to this matrix.
-    #[inline(always)]
-    fn apply_mut<F, O>(&mut self, mut f: F) -> O
+    fn apply<F, O>(&mut self, mut f: F) -> O
     where
         F: FnMut(&mut Self) -> O,
     {

--- a/crates/minikalman/src/observations.rs
+++ b/crates/minikalman/src/observations.rs
@@ -761,7 +761,7 @@ mod tests {
         measurement
             .measurement_vector()
             .as_matrix()
-            .inspect_mut(|_vec| test_fn_mut());
+            .inspect(|_vec| test_fn_mut());
         measurement
             .measurement_vector_mut()
             .as_matrix_mut()
@@ -769,7 +769,7 @@ mod tests {
         measurement
             .measurement_vector_mut()
             .as_matrix_mut()
-            .apply_mut(|_vec| test_fn_mut());
+            .apply(|_vec| test_fn_mut());
 
         let _mat = measurement.observation_matrix();
         let _mat = measurement.observation_matrix_mut();
@@ -780,7 +780,7 @@ mod tests {
         let _ = measurement
             .observation_matrix()
             .as_matrix()
-            .inspect_mut(|_mat| test_fn_mut());
+            .inspect(|_mat| test_fn_mut());
         measurement
             .observation_matrix_mut()
             .as_matrix_mut()
@@ -788,7 +788,7 @@ mod tests {
         measurement
             .observation_matrix_mut()
             .as_matrix_mut()
-            .apply_mut(|_mat| test_fn_mut());
+            .apply(|_mat| test_fn_mut());
 
         let _mat = measurement.measurement_noise_covariance();
         let _mat = measurement.measurement_noise_covariance_mut();
@@ -799,7 +799,7 @@ mod tests {
         let _ = measurement
             .measurement_noise_covariance()
             .as_matrix()
-            .inspect_mut(|_mat| test_fn_mut());
+            .inspect(|_mat| test_fn_mut());
         measurement
             .measurement_noise_covariance_mut()
             .as_matrix_mut()
@@ -807,7 +807,7 @@ mod tests {
         measurement
             .measurement_noise_covariance_mut()
             .as_matrix_mut()
-            .apply_mut(|_mat| test_fn_mut());
+            .apply(|_mat| test_fn_mut());
 
         measurement
     }
@@ -848,7 +848,7 @@ mod tests {
         let _ = measurement
             .measurement_vector()
             .as_matrix()
-            .inspect_mut(|_vec| test_fn_mut());
+            .inspect(|_vec| test_fn_mut());
         measurement
             .measurement_vector_mut()
             .as_matrix_mut()
@@ -856,7 +856,7 @@ mod tests {
         measurement
             .measurement_vector_mut()
             .as_matrix_mut()
-            .apply_mut(|_vec| test_fn_mut());
+            .apply(|_vec| test_fn_mut());
 
         let _mat = measurement.observation_matrix();
         let _mat = measurement.observation_matrix_mut();
@@ -867,7 +867,7 @@ mod tests {
         let _ = measurement
             .observation_matrix()
             .as_matrix()
-            .inspect_mut(|_mat| test_fn_mut());
+            .inspect(|_mat| test_fn_mut());
         measurement
             .observation_matrix_mut()
             .as_matrix_mut()
@@ -875,7 +875,7 @@ mod tests {
         measurement
             .observation_matrix_mut()
             .as_matrix_mut()
-            .apply_mut(|_mat| test_fn_mut());
+            .apply(|_mat| test_fn_mut());
 
         let _mat = measurement.measurement_noise_covariance();
         let _mat = measurement.measurement_noise_covariance_mut();
@@ -886,7 +886,7 @@ mod tests {
         let _ = measurement
             .measurement_noise_covariance()
             .as_matrix()
-            .inspect_mut(|_mat| test_fn_mut());
+            .inspect(|_mat| test_fn_mut());
         measurement
             .measurement_noise_covariance_mut()
             .as_matrix_mut()
@@ -894,6 +894,6 @@ mod tests {
         measurement
             .measurement_noise_covariance_mut()
             .as_matrix_mut()
-            .apply_mut(|_mat| test_fn_mut());
+            .apply(|_mat| test_fn_mut());
     }
 }


### PR DESCRIPTION
This simply makes `FnMut` closures the default.