### PR TITLE
EKF example: Radar measurements of a moving object

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,8 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: Run Example (float)
         run: cargo run --example=gravity --no-default-features --features=std
+      - name: Run EKF example
+        run: cargo run --example=radar-2d --no-default-features --features=std
       - name: Run tests (std)
         run: cargo nextest run --verbose --package minikalman --no-default-features --features=std
       - name: Run tests (libm)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Generate code coverage
-        run: cargo llvm-cov nextest --features=std,fixed,alloc --package minikalman --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --features=std,fixed,alloc --workspace --exclude stm32 --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - [#8](https://github.com/sunsided/minikalman-rs/pull/8):
   The repository was restructured into a Cargo workspace to allow for easier handling of cross-compilation examples.
+- [#27](https://github.com/sunsided/minikalman-rs/pull/27):
+  Added an EKF example with radar measurements of a moving object.
 
 ## [0.4.0] - 2024-06-07
 

--- a/crates/minikalman/Cargo.toml
+++ b/crates/minikalman/Cargo.toml
@@ -41,12 +41,12 @@ required-features = ["fixed", "std", "alloc"]
 [[example]]
 name = "car-1d"
 path = "examples/car_1d.rs"
-required-features = ["alloc"]
+required-features = ["std"]
 
 [[example]]
 name = "radar-2d"
 path = "examples/radar_2d.rs"
-required-features = ["alloc"]
+required-features = ["std"]
 
 [features]
 default = ["libm", "alloc"]

--- a/crates/minikalman/Cargo.toml
+++ b/crates/minikalman/Cargo.toml
@@ -43,6 +43,11 @@ name = "car-1d"
 path = "examples/car_1d.rs"
 required-features = ["alloc"]
 
+[[example]]
+name = "radar-2d"
+path = "examples/radar_2d.rs"
+required-features = ["alloc"]
+
 [features]
 default = ["libm", "alloc"]
 std = ["num-traits/std", "alloc"]

--- a/crates/minikalman/examples/car_1d.rs
+++ b/crates/minikalman/examples/car_1d.rs
@@ -119,16 +119,16 @@ fn main() {
         filter.control(&mut control);
 
         if t % 2 != 0 {
-            print_state(t, &filter, State::Prior);
+            print_state(t, &filter, Stage::Prior);
         } else {
-            print_state(t, &filter, State::PriorAboutToUpdate);
+            print_state(t, &filter, Stage::PriorAboutToUpdate);
 
             measurement.measurement_vector_mut().apply(|measurement| {
                 measurement[0] = OBSERVATIONS[t - 10];
             });
 
             filter.correct(&mut measurement);
-            print_state(t, &filter, State::Posterior);
+            print_state(t, &filter, Stage::Posterior);
         }
     }
 
@@ -141,20 +141,20 @@ fn main() {
     }
 }
 
-enum State {
+enum Stage {
     Prior,
     PriorAboutToUpdate,
     Posterior,
 }
 
-fn print_state<T>(time: usize, filter: &T, state: State)
+fn print_state<T>(time: usize, filter: &T, state: Stage)
 where
     T: KalmanFilter<3, f32>,
 {
     let marker = match state {
-        State::Prior => ' ',
-        State::PriorAboutToUpdate => ' ',
-        State::Posterior => '✅',
+        Stage::Prior => ' ',
+        Stage::PriorAboutToUpdate => ' ',
+        Stage::Posterior => '✅',
     };
 
     let state = filter.state_vector();

--- a/crates/minikalman/examples/radar_2d.rs
+++ b/crates/minikalman/examples/radar_2d.rs
@@ -1,0 +1,145 @@
+//! Tracking a free-falling object.
+//!
+//! This example sets up a filter to estimate the acceleration of a free-falling object
+//! under earth conditions (i.e. a ≈ 9.807 m/s²) through position observations only.
+
+#![forbid(unsafe_code)]
+
+use rand_distr::{Distribution, Normal};
+
+use minikalman::builder::KalmanFilterBuilder;
+use minikalman::prelude::*;
+
+const NUM_STATES: usize = 4; // position (x, y), velocity (x, y)
+const NUM_OBSERVATIONS: usize = 1; // distance to object
+
+#[allow(non_snake_case)]
+fn main() {
+    let builder = KalmanFilterBuilder::<NUM_STATES, f32>::default();
+    let mut filter = builder.build();
+    let mut measurement = builder.observations().build::<NUM_OBSERVATIONS>();
+
+    // The time step of our simulation.
+    const DELTA_T: f32 = 0.1;
+
+    // Update the filter every N steps.
+    const OBSERVE_EVERY: usize = 10;
+
+    // Set up the initial state vector.
+    filter.state_vector_mut().apply(|vec| {
+        vec.set_row(0, 0.0);
+        vec.set_row(1, 0.0);
+        vec.set_row(2, 1.0);
+        vec.set_row(3, 1.0);
+    });
+
+    // Set up the initial estimate covariance as an identity matrix.
+    filter.estimate_covariance_mut().make_identity();
+
+    // Set up the process noise covariance matrix as an identity matrix.
+    measurement
+        .measurement_noise_covariance_mut()
+        .make_scalar(0.1);
+
+    // Set up the measurement noise covariance.
+    measurement.measurement_noise_covariance_mut().apply(|mat| {
+        mat.set_value(0.5); // matrix is 1x1
+    });
+
+    // Simulate
+    for step in 1..=100 {
+        let time = step as f32 * DELTA_T;
+
+        // Update the system transition Jacobian matrix.
+        filter.state_transition_mut().apply(|mat| {
+            mat.make_identity();
+            mat.set(0, 2, DELTA_T);
+            mat.set(1, 3, DELTA_T);
+        });
+
+        // Perform a nonlinear prediction step.
+        filter.predict_nonlinear(|state, next| {
+            next[0] = state[0] + state[2] * DELTA_T;
+            next[1] = state[1] + state[3] * DELTA_T;
+            next[2] = state[2];
+            next[3] = state[3];
+        });
+
+        if step % OBSERVE_EVERY != 0 {
+            print_state(time, &filter, Stage::Prior);
+        } else {
+            print_state(time, &filter, Stage::PriorAboutToUpdate);
+
+            // Prepare a measurement.
+            measurement.measurement_vector_mut().apply(|vec| {
+                // Noise setup.
+                let mut rng = rand::thread_rng();
+                let measurement_noise = Normal::new(0.0, 0.5).unwrap();
+
+                // Perform a noisy measurement of the (simulated) position.
+                let z = (time.powi(2) + time.powi(2)).sqrt();
+                let noise = measurement_noise.sample(&mut rng);
+
+                vec.set_value(z + noise);
+            });
+
+            // Update the observation Jacobian.
+            measurement.observation_matrix_mut().apply(|mat| {
+                let x = filter.state_vector().get_row(0);
+                let y = filter.state_vector().get_row(1);
+
+                let norm = (x.powi(2) + y.powi(2)).sqrt();
+                let dx = x / norm;
+                let dy = y / norm;
+
+                mat.set_col(0, dx);
+                mat.set_col(1, dy);
+                mat.set_col(2, 0.0);
+                mat.set_col(3, 0.0);
+            });
+
+            // Apply nonlinear correction step.
+            filter.correct_nonlinear(&mut measurement, |state, observation| {
+                // We transform the state into an observation.
+                let x = state.get_row(0);
+                let y = state.get_row(1);
+                let z = (x.powi(2) + y.powi(2)).sqrt();
+                observation.set_value(z);
+            });
+
+            print_state(time, &filter, Stage::Posterior);
+        }
+    }
+}
+
+enum Stage {
+    Prior,
+    PriorAboutToUpdate,
+    Posterior,
+}
+
+fn print_state<T>(time: f32, filter: &T, state: Stage)
+where
+    T: KalmanFilter<4, f32>,
+{
+    let marker = match state {
+        Stage::Prior => ' ',
+        Stage::PriorAboutToUpdate => '-',
+        Stage::Posterior => '+',
+    };
+
+    let state = filter.state_vector();
+
+    let covariances = filter.estimate_covariance();
+    let covariances = covariances.as_matrix();
+
+    let std_x = covariances.get(0, 0).sqrt();
+    let std_y = covariances.get(1, 1).sqrt();
+    let std_vx = covariances.get(2, 2).sqrt();
+    let std_vy = covariances.get(3, 3).sqrt();
+
+    println!(
+        "{} t={:.2} s,  x={:.2} ± {:.2} m\n              x={:.2} ± {:.2} m\n             vx={:2.2} ± {:.2} m/s\n             vy={:2.2} ± {:.2} m/s",
+        marker, time, state[0], std_x, state[1], std_y, state[2], std_vx, state[3], std_vy
+    );
+}

--- a/crates/minikalman/examples/radar_2d.rs
+++ b/crates/minikalman/examples/radar_2d.rs
@@ -29,8 +29,8 @@ fn main() {
     filter.state_vector_mut().apply(|vec| {
         vec.set_row(0, 0.0);
         vec.set_row(1, 0.0);
-        vec.set_row(2, 1.0);
-        vec.set_row(3, 1.0);
+        vec.set_row(2, 2.0); // Overestimates the actual velocity (1 m/s)
+        vec.set_row(3, 2.0); // Overestimates the actual velocity (1 m/s)
     });
 
     // Set up the initial estimate covariance as an identity matrix.

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -739,6 +739,16 @@ impl<const STATES: usize, T, A, X, P, PX, TempP> Kalman<STATES, T, A, X, P, PX, 
         measurement.correct(&mut self.x, &mut self.P);
     }
 
+    /// Performs the nonlinear measurement update step.
+    ///
+    /// ## Extended Kalman Filters
+    /// This function expects that the Jacobian of the observation transformation function
+    /// is correctly set up for the measurement. See [`KalmanFilterObservationTransformationMut`](KalmanFilterObservationTransformationMut::observation_matrix_mut)
+    /// for more information.
+    ///
+    /// ## Arguments
+    /// * `measurement` - The measurement.
+    /// * `observation` - The observation function.
     pub fn correct_nonlinear<M, F, const OBSERVATIONS: usize>(
         &mut self,
         measurement: &mut M,

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -153,7 +153,7 @@ impl<const STATES: usize, T, A, X, P, PX, TempP> Kalman<STATES, T, A, X, P, PX, 
 where
     A: StateTransitionMatrix<STATES, T>,
 {
-    /// Gets a reference to the state transition matrix A/F.
+    /// Gets a reference to the state transition matrix A/F, or its Jacobian
     ///
     /// ## (Regular) Kalman Filters
     /// This matrix describes how the state vector evolves from one time step to the next in the
@@ -161,9 +161,9 @@ where
     /// current state, accounting for the inherent dynamics of the system.
     ///
     /// ## Extended Kalman Filters
-    /// In Extended Kalman Filters, this matrix is treated as the Jacobian of the state
-    /// transition matrix, i.e. the derivative of the state transition matrix with respect
-    /// to the state vector.
+    /// When updating using [`correct_nonlinear`](Self::correct_nonlinear),
+    /// this matrix is treated as the Jacobian of the state transition matrix, i.e. the derivative
+    /// of the state transition matrix with respect to the state vector.
     ///
     /// See e.g. [`predict_nonlinear`](Self::predict_nonlinear) for use.
     #[inline(always)]
@@ -178,16 +178,16 @@ impl<const STATES: usize, T, A, X, P, PX, TempP> Kalman<STATES, T, A, X, P, PX, 
 where
     A: StateTransitionMatrixMut<STATES, T>,
 {
-    /// Gets a reference to the state transition matrix A/F.
+    /// Gets a reference to the state transition matrix A/F, or its Jacobian.
     ///
     /// This matrix describes how the state vector evolves from one time step to the next in the
     /// absence of control inputs. It defines the relationship between the previous state and the
     /// current state, accounting for the inherent dynamics of the system.
     ///
     /// ## Extended Kalman Filters
-    /// In Extended Kalman Filters, this matrix is treated as the Jacobian of the state
-    /// transition matrix, i.e. the derivative of the state transition matrix with respect
-    /// to the state vector.
+    /// When updating using [`correct_nonlinear`](Self::correct_nonlinear),
+    /// this matrix is treated as the Jacobian of the state transition matrix, i.e. the derivative
+    /// of the state transition matrix with respect to the state vector.
     ///
     /// See e.g. [`predict_nonlinear`](Self::predict_nonlinear) for use.
     #[inline(always)]

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -1220,10 +1220,19 @@ mod tests {
             .inspect(|mat| (0..3).into_iter().all(|i| { mat.get(i, i) == 0.1 })));
 
         // Trivial state progression.
-        for _ in 0..10 {
+        for _ in 0..5 {
+            // Direct call.
             example.filter.predict_nonlinear(|current, next| {
                 current.copy(next);
             });
+
+            // Call via trait.
+            KalmanFilterNonlinearPredict::predict_nonlinear(
+                &mut example.filter,
+                |current, next| {
+                    current.copy(next);
+                },
+            );
         }
 
         // All states are zero.

--- a/crates/minikalman/src/kalman.rs
+++ b/crates/minikalman/src/kalman.rs
@@ -869,6 +869,30 @@ where
     }
 }
 
+impl<const STATES: usize, T, A, X, P, PX, TempP> KalmanFilterNonlinearPredict<STATES, T>
+    for Kalman<STATES, T, A, X, P, PX, TempP>
+where
+    X: StateVectorMut<STATES, T>,
+    A: StateTransitionMatrix<STATES, T>,
+    PX: PredictedStateEstimateVector<STATES, T>,
+    P: EstimateCovarianceMatrix<STATES, T>,
+    TempP: TemporaryStateMatrix<STATES, T>,
+    T: MatrixDataType,
+{
+    type NextStateVector = PX;
+
+    #[inline(always)]
+    fn predict_nonlinear<F>(&mut self, state_transition: F)
+    where
+        F: FnMut(
+            &<Self as KalmanFilterStateVectorMut<STATES, T>>::StateVectorMut,
+            &mut Self::NextStateVector,
+        ),
+    {
+        self.predict_nonlinear(state_transition)
+    }
+}
+
 impl<const STATES: usize, T, A, X, P, PX, TempP> KalmanFilterNonlinearUpdate<STATES, T>
     for Kalman<STATES, T, A, X, P, PX, TempP>
 where
@@ -883,7 +907,7 @@ where
         observation: F,
     ) where
         M: KalmanFilterNonlinearObservationCorrectFilter<STATES, OBSERVATIONS, T>,
-        F: FnMut(&X, &mut M::ObservationVector), // TODO: Camouflage Y as a temporary, nonlinear Z?
+        F: FnMut(&X, &mut M::ObservationVector),
     {
         self.correct_nonlinear(measurement, observation)
     }

--- a/crates/minikalman/src/matrix/data.rs
+++ b/crates/minikalman/src/matrix/data.rs
@@ -451,6 +451,9 @@ mod tests {
     use super::*;
     use assert_float_eq::*;
 
+    use crate::prelude::{
+        ColumnVector, ColumnVectorMut, RowVector, RowVectorMut, Scalar, ScalarMut,
+    };
     #[cfg(feature = "unsafe")]
     use core::ptr::addr_of;
 
@@ -646,5 +649,35 @@ mod tests {
         assert_eq!(a.buffer_len(), 6);
         assert!(!a.is_empty());
         assert!(a.is_valid());
+    }
+
+    #[test]
+    fn row_vector() {
+        let mut a_buf = [1.0, 2.0, 3.0];
+        let mut a = MatrixDataMut::<3, 1, f32>::from(a_buf.as_mut());
+        assert_eq!(a.get_row(0), 1.0);
+
+        a.set_row(0, 0.0);
+        assert_eq!(a.get_row(0), 0.0);
+    }
+
+    #[test]
+    fn column_vector() {
+        let mut a_buf = [1.0, 2.0, 3.0];
+        let mut a = MatrixDataMut::<1, 3, f32>::from(a_buf.as_mut());
+        assert_eq!(a.get_col(0), 1.0);
+
+        a.set_col(0, 0.0);
+        assert_eq!(a.get_col(0), 0.0);
+    }
+
+    #[test]
+    fn scalar() {
+        let mut a_buf = [1.0, 2.0, 3.0];
+        let mut a = MatrixDataMut::<1, 1, f32>::from(a_buf.as_mut());
+        assert_eq!(a.get_value(), 1.0);
+
+        a.set_value(0.0);
+        assert_eq!(a.get_value(), 0.0);
     }
 }

--- a/crates/minikalman/src/matrix/traits.rs
+++ b/crates/minikalman/src/matrix/traits.rs
@@ -878,6 +878,74 @@ pub trait SquareMatrixMut<const N: usize, T = f32>: AsMut<[T]> + SquareMatrix<N,
 impl<const N: usize, T, M> SquareMatrix<N, T> for M where M: Matrix<N, N, T> {}
 impl<const N: usize, T, M> SquareMatrixMut<N, T> for M where M: MatrixMut<N, N, T> {}
 
+pub trait Scalar<T = f32>: Matrix<1, 1, T> {
+    /// Gets the value of a matrix of size 1×1.
+    #[inline(always)]
+    fn get_value(&self) -> T
+    where
+        T: Copy,
+    {
+        self.get(0, 0)
+    }
+}
+
+pub trait RowVector<const ROWS: usize, T = f32>: Matrix<ROWS, 1, T> {
+    /// Gets the value of the n-th row of a matrix of size N×1.
+    #[inline(always)]
+    fn get_row(&self, row: usize) -> T
+    where
+        T: Copy,
+    {
+        self.get(row, 0)
+    }
+}
+
+pub trait ColumnVector<const COLS: usize, T = f32>: Matrix<1, COLS, T> {
+    /// Gets the value of the n-th column of a matrix of size 1×N.
+    #[inline(always)]
+    fn get_col(&self, column: usize) -> T
+    where
+        T: Copy,
+    {
+        self.get(0, column)
+    }
+}
+
+pub trait ScalarMut<T = f32>: MatrixMut<1, 1, T> {
+    /// Sets the value of a matrix of size 1×1.
+    #[inline(always)]
+    fn set_value(&mut self, value: T) {
+        self.set(0, 0, value)
+    }
+}
+
+pub trait RowVectorMut<const ROWS: usize, T = f32>:
+    MatrixMut<ROWS, 1, T> + RowVector<ROWS, T>
+{
+    /// Sets the value of the n-th row of a matrix of size N×1.
+    #[inline(always)]
+    fn set_row(&mut self, row: usize, value: T) {
+        self.set(row, 0, value)
+    }
+}
+
+pub trait ColumnVectorMut<const COLS: usize, T = f32>:
+    MatrixMut<1, COLS, T> + ColumnVector<COLS, T>
+{
+    /// Sets the value of the n-th column of a matrix of size 1×N.
+    #[inline(always)]
+    fn set_col(&mut self, column: usize, value: T) {
+        self.set(0, column, value)
+    }
+}
+
+impl<T, M> Scalar<T> for M where M: Matrix<1, 1, T> {}
+impl<T, M> ScalarMut<T> for M where M: MatrixMut<1, 1, T> {}
+impl<const N: usize, T, M> RowVector<N, T> for M where M: Matrix<N, 1, T> {}
+impl<const N: usize, T, M> RowVectorMut<N, T> for M where M: MatrixMut<N, 1, T> {}
+impl<const N: usize, T, M> ColumnVector<N, T> for M where M: Matrix<1, N, T> {}
+impl<const N: usize, T, M> ColumnVectorMut<N, T> for M where M: MatrixMut<1, N, T> {}
+
 /// A mutable matrix wrapping a data buffer.
 pub trait MatrixMut<const ROWS: usize, const COLS: usize, T = f32>:
     Matrix<ROWS, COLS, T> + AsMut<[T]> + IndexMut<usize, Output = T>

--- a/crates/minikalman/src/observations.rs
+++ b/crates/minikalman/src/observations.rs
@@ -233,6 +233,10 @@ impl<
     /// This matrix maps the state vector into the measurement space, relating the state of the
     /// system to the observations or measurements. It defines how each state component contributes
     /// to the measurement.
+    ///
+    /// ## Extended Kalman Filters
+    /// In Extended Kalman Filters, this matrix is treated as the Jacobian of the observation matrix,
+    /// i.e. the derivative of the measurement function with respect to the state vector.
     #[inline(always)]
     pub fn observation_matrix(&self) -> &H {
         &self.H
@@ -425,6 +429,10 @@ where
     /// This matrix maps the state vector into the measurement space, relating the state of the
     /// system to the observations or measurements. It defines how each state component contributes
     /// to the measurement.
+    ///
+    /// ## Extended Kalman Filters
+    /// In Extended Kalman Filters, this matrix is treated as the Jacobian of the observation matrix,
+    /// i.e. the derivative of the measurement function with respect to the state vector.
     #[inline(always)]
     #[doc(alias = "kalman_get_measurement_transformation")]
     pub fn observation_matrix_mut(&mut self) -> &mut H {


### PR DESCRIPTION
This adds a simple example for Extended Kalman Filters that simulate distance-only measurments of a moving object in 2D.